### PR TITLE
feat: ChatService intent 핸들러 연결 — 실서비스 호출 (#41)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -15,13 +15,6 @@ _(없음)_
 > 스펙 문서: `markdowns/feat-chat-dashboard.md`
 > 이 목록은 시드 태스크다. evolve가 Architect 단계에서 스펙을 분석하고 추가 태스크를 자율적으로 생성한다.
 
-- [ ] #41 - ChatService intent 핸들러 연결 (create_plan → GeminiService, search → SearchService) [feature]
-  - ref: markdowns/feat-chat-dashboard.md "Phase 1"
-  - depends: #39
-  - files: src/app/chat.py (modify)
-  - done: intent에 따라 기존 서비스를 호출하고 결과를 SSE 이벤트로 emit. 테스트 통과.
-  - gh: #4
-
 ### Phase 9: User Experience & Polish (remaining)
 
 - [ ] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature]
@@ -88,11 +81,12 @@ _(없음)_
 ### Phase 10: Chat + Multi-Agent Dashboard
 - [x] #39 - ChatService 기본 구조 (ConversationState, intent 추출, 세션 관리) [feature] — 2026-04-03
 - [x] #40 - Chat SSE 스트리밍 엔드포인트 (POST /chat/sessions, SSE messages, GET/DELETE) [feature] — 2026-04-04
+- [x] #41 - ChatService intent 핸들러 연결 (create_plan → GeminiService, search → SearchService) [feature] — 2026-04-04
 
 ---
 
 ## Metrics
 
 - Velocity: 1 task/run
-- Total tasks: 36 done, 5 ready
+- Total tasks: 37 done, 4 ready
 - Phase: 10 (Chat + Multi-Agent Dashboard)

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,11 +1,11 @@
 {
-  "last_updated": "2026-04-04T00:00Z",
+  "last_updated": "2026-04-04T06:20Z",
   "summary": {
-    "total_runs": 60,
-    "total_commits": 65,
-    "total_tests": 1037,
-    "tasks_completed": 36,
-    "tasks_remaining": 5,
+    "total_runs": 61,
+    "total_commits": 66,
+    "total_tests": 1054,
+    "tasks_completed": 37,
+    "tasks_remaining": 4,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
     "health": "GREEN"
   },
@@ -39,11 +39,11 @@
     },
     {
       "date": "2026-04-04",
-      "runs": 1,
-      "tasks_completed": 1,
-      "tests_passed": 1037,
+      "runs": 2,
+      "tasks_completed": 2,
+      "tests_passed": 1054,
       "tests_failed": 0,
-      "commits": 1,
+      "commits": 2,
       "health": "GREEN"
     }
   ],
@@ -54,8 +54,8 @@
     "saturation_tokens_per_day": 0
   },
   "last_monitor": {
-    "timestamp": "2026-04-04T00:00Z",
-    "tests_passed": 1037,
+    "timestamp": "2026-04-04T06:20Z",
+    "tests_passed": 1054,
     "tests_failed": 0,
     "health": "GREEN"
   }

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,8 +7,8 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 60,
-    "successful_runs": 56,
+    "total_runs": 61,
+    "successful_runs": 57,
     "failed_runs": 0,
     "success_rate": 1.0,
     "budget_remaining": 1.0,
@@ -79,6 +79,7 @@
     {"run_id": "monitor-2026-04-03-1929", "task": "monitor", "result": "success", "tests_passed": 994, "tests_total": 994},
     {"run_id": "monitor-2026-04-03-2026", "task": "monitor", "result": "success", "tests_passed": 994, "tests_total": 994},
     {"run_id": "2026-04-03-2100", "task": "#39 - ChatService 기본 구조", "result": "success", "tests_passed": 1037, "tests_total": 1037},
-    {"run_id": "2026-04-04-0000", "task": "#40 - Chat SSE 스트리밍 엔드포인트", "result": "success", "tests_passed": 1037, "tests_total": 1037}
+    {"run_id": "2026-04-04-0000", "task": "#40 - Chat SSE 스트리밍 엔드포인트", "result": "success", "tests_passed": 1037, "tests_total": 1037},
+    {"run_id": "2026-04-04-0620", "task": "#41 - ChatService intent 핸들러 연결", "result": "success", "tests_passed": 1054, "tests_total": 1054}
   ]
 }

--- a/observability/logs/2026-04-04/run-06-20.json
+++ b/observability/logs/2026-04-04/run-06-20.json
@@ -1,0 +1,49 @@
+{
+  "trace": {
+    "run_id": "2026-04-04-0620",
+    "timestamp": "2026-04-04T06:20:00Z",
+    "phase": "Phase 10",
+    "health": "GREEN",
+    "task": "#41 - ChatService intent 핸들러 연결 (create_plan → GeminiService, search → SearchService)",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "pass",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Health GREEN (1037/1037 tests). Selected task #41. No architect needed (5 ready tasks)."
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "backlog_ready_count=5 >= 2, architect not needed"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "Modified src/app/chat.py and tests/test_chat.py. +197 lines added, -52 removed. 17 new integration tests. 1054/1054 tests pass."
+    },
+    {
+      "agent": "qa",
+      "status": "pass",
+      "detail": "All checks pass: tests 1054/1054, lint clean, done criteria met, no regressions, no secrets leaked."
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Writing logs, updating status/backlog/error-budget, creating PR."
+    }
+  ],
+  "ltes": {
+    "latency": {"total_duration_ms": 16080},
+    "traffic": {"commits": 1, "lines_added": 197, "lines_removed": 52, "files_changed": 2},
+    "errors": {"test_failures": 0, "fix_attempts": 0},
+    "saturation": {"backlog_remaining": 4}
+  }
+}

--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -2,16 +2,22 @@
 
 import asyncio
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import AsyncGenerator, Optional
 
 from google import genai
 from google.genai import types
 from pydantic import BaseModel
 
+from app.ai import GeminiService
 from app.config import GEMINI_API_KEY
+from app.flight_search import FlightSearchService
+from app.hotel_search import HotelSearchService
+from app.web_search import WebSearchService
 
 SESSION_TTL_SECONDS = 1800  # 30 minutes
+
+_DEFAULT_DEPARTURE = "Seoul"  # default origin for flight search
 
 
 class Intent(BaseModel):
@@ -34,10 +40,22 @@ class ChatSession(BaseModel):
 
 
 class ChatService:
-    def __init__(self, api_key: str = "", ttl_seconds: int = SESSION_TTL_SECONDS):
+    def __init__(
+        self,
+        api_key: str = "",
+        ttl_seconds: int = SESSION_TTL_SECONDS,
+        gemini_service: Optional[GeminiService] = None,
+        web_search_service: Optional[WebSearchService] = None,
+        hotel_search_service: Optional[HotelSearchService] = None,
+        flight_search_service: Optional[FlightSearchService] = None,
+    ):
         self._api_key = api_key or GEMINI_API_KEY
         self._ttl = ttl_seconds
         self._sessions: dict[str, ChatSession] = {}
+        self._gemini = gemini_service or GeminiService(api_key=self._api_key)
+        self._web_search = web_search_service or WebSearchService(api_key=self._api_key)
+        self._hotel_search = hotel_search_service or HotelSearchService(api_key=self._api_key)
+        self._flight_search = flight_search_service or FlightSearchService(api_key=self._api_key)
 
     # ------------------------------------------------------------------
     # Session management
@@ -178,8 +196,29 @@ Return a JSON object with these fields:
     # Intent handlers
     # ------------------------------------------------------------------
 
+    def _parse_dates(self, intent: Intent) -> tuple[date, date]:
+        """Parse start/end dates from intent, falling back to sensible defaults."""
+        try:
+            start = date.fromisoformat(intent.start_date) if intent.start_date else None
+        except ValueError:
+            start = None
+        try:
+            end = date.fromisoformat(intent.end_date) if intent.end_date else None
+        except ValueError:
+            end = None
+
+        if start is None:
+            start = date.today() + timedelta(days=30)
+        if end is None:
+            end = start + timedelta(days=3)
+        return start, end
+
     async def _handle_create_plan(self, intent: Intent) -> AsyncGenerator[dict, None]:
         dest = intent.destination or "목적지"
+        budget = intent.budget or 2000.0
+        interests = intent.interests or ""
+        start, end = self._parse_dates(intent)
+
         yield {
             "type": "agent_status",
             "data": {"agent": "place_scout", "status": "working", "message": f"{dest} 장소 검색 중..."},
@@ -190,73 +229,201 @@ Return a JSON object with these fields:
         }
         yield {
             "type": "agent_status",
-            "data": {"agent": "planner", "status": "working", "message": "일정 구성 준비 중..."},
+            "data": {"agent": "planner", "status": "working", "message": "일정 구성 중..."},
         }
-        await asyncio.sleep(0)
-        yield {
-            "type": "agent_status",
-            "data": {"agent": "place_scout", "status": "done", "message": "장소 검색 완료"},
-        }
-        yield {
-            "type": "agent_status",
-            "data": {"agent": "budget_analyst", "status": "done", "message": "예산 배분 완료"},
-        }
-        yield {
-            "type": "agent_status",
-            "data": {"agent": "planner", "status": "done", "message": "일정 완성!"},
-        }
-        yield {
-            "type": "chat_chunk",
-            "data": {"text": f"{dest} 여행 계획을 생성했습니다."},
-        }
+
+        try:
+            result = await asyncio.to_thread(
+                self._gemini.generate_itinerary,
+                dest, start, end, budget, interests,
+            )
+
+            place_count = sum(len(day.places) for day in result.days)
+            yield {
+                "type": "agent_status",
+                "data": {
+                    "agent": "place_scout",
+                    "status": "done",
+                    "message": f"{place_count}개 장소 찾음",
+                    "result_count": place_count,
+                },
+            }
+            yield {
+                "type": "agent_status",
+                "data": {
+                    "agent": "budget_analyst",
+                    "status": "done",
+                    "message": f"총 ${result.total_estimated_cost:.0f} 예산 배분 완료",
+                },
+            }
+
+            # Emit full plan then per-day updates
+            yield {"type": "plan_update", "data": result.model_dump()}
+            for day in result.days:
+                yield {"type": "day_update", "data": day.model_dump()}
+
+            yield {
+                "type": "agent_status",
+                "data": {
+                    "agent": "planner",
+                    "status": "done",
+                    "message": f"{len(result.days)}일 일정 완성!",
+                },
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"{dest} {len(result.days)}일 여행 계획을 생성했습니다."},
+            }
+
+        except Exception as exc:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "planner", "status": "error", "message": "일정 생성 실패"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"일정 생성 중 오류가 발생했습니다: {exc}"},
+            }
 
     async def _handle_search_hotels(self, intent: Intent) -> AsyncGenerator[dict, None]:
         dest = intent.destination or "목적지"
+        start, end = self._parse_dates(intent)
+        budget_per_night = int(intent.budget / (end - start).days) if intent.budget else 0
+
         yield {
             "type": "agent_status",
             "data": {"agent": "hotel_finder", "status": "working", "message": f"{dest} 숙소 검색 중..."},
         }
-        await asyncio.sleep(0)
-        yield {
-            "type": "agent_status",
-            "data": {"agent": "hotel_finder", "status": "done", "message": "숙소 검색 완료"},
-        }
-        yield {
-            "type": "chat_chunk",
-            "data": {"text": f"{dest} 숙소를 검색했습니다."},
-        }
+
+        try:
+            result = await asyncio.to_thread(
+                self._hotel_search.search_hotels,
+                dest,
+                start.isoformat(),
+                end.isoformat(),
+                budget_per_night,
+            )
+
+            hotel_count = len(result.hotels)
+            yield {
+                "type": "agent_status",
+                "data": {
+                    "agent": "hotel_finder",
+                    "status": "done",
+                    "message": f"{hotel_count}개 숙소 찾음",
+                    "result_count": hotel_count,
+                },
+            }
+            yield {
+                "type": "search_results",
+                "data": {"type": "hotels", "results": result.model_dump()},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"{dest} 숙소 {hotel_count}개를 찾았습니다."},
+            }
+
+        except Exception as exc:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "hotel_finder", "status": "error", "message": "숙소 검색 실패"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"숙소 검색 중 오류가 발생했습니다: {exc}"},
+            }
 
     async def _handle_search_flights(self, intent: Intent) -> AsyncGenerator[dict, None]:
         dest = intent.destination or "목적지"
+        start, end = self._parse_dates(intent)
+
         yield {
             "type": "agent_status",
             "data": {"agent": "flight_finder", "status": "working", "message": f"{dest} 항공편 검색 중..."},
         }
-        await asyncio.sleep(0)
-        yield {
-            "type": "agent_status",
-            "data": {"agent": "flight_finder", "status": "done", "message": "항공편 검색 완료"},
-        }
-        yield {
-            "type": "chat_chunk",
-            "data": {"text": f"{dest} 항공편을 검색했습니다."},
-        }
+
+        try:
+            result = await asyncio.to_thread(
+                self._flight_search.search_flights,
+                _DEFAULT_DEPARTURE,
+                dest,
+                start.isoformat(),
+                end.isoformat(),
+            )
+
+            flight_count = len(result.flights)
+            yield {
+                "type": "agent_status",
+                "data": {
+                    "agent": "flight_finder",
+                    "status": "done",
+                    "message": f"{flight_count}개 항공편 찾음",
+                    "result_count": flight_count,
+                },
+            }
+            yield {
+                "type": "search_results",
+                "data": {"type": "flights", "results": result.model_dump()},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"{dest} 항공편 {flight_count}개를 찾았습니다."},
+            }
+
+        except Exception as exc:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "flight_finder", "status": "error", "message": "항공편 검색 실패"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"항공편 검색 중 오류가 발생했습니다: {exc}"},
+            }
 
     async def _handle_search_places(self, intent: Intent) -> AsyncGenerator[dict, None]:
         dest = intent.destination or "목적지"
+        interests = intent.interests or ""
+
         yield {
             "type": "agent_status",
             "data": {"agent": "place_scout", "status": "working", "message": f"{dest} 장소 검색 중..."},
         }
-        await asyncio.sleep(0)
-        yield {
-            "type": "agent_status",
-            "data": {"agent": "place_scout", "status": "done", "message": "장소 검색 완료"},
-        }
-        yield {
-            "type": "chat_chunk",
-            "data": {"text": f"{dest} 장소를 검색했습니다."},
-        }
+
+        try:
+            result = await asyncio.to_thread(
+                self._web_search.search_places,
+                dest,
+                interests,
+            )
+
+            place_count = len(result.places)
+            yield {
+                "type": "agent_status",
+                "data": {
+                    "agent": "place_scout",
+                    "status": "done",
+                    "message": f"{place_count}개 장소 찾음",
+                    "result_count": place_count,
+                },
+            }
+            yield {
+                "type": "search_results",
+                "data": {"type": "places", "results": result.model_dump()},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"{dest} 장소 {place_count}개를 찾았습니다."},
+            }
+
+        except Exception as exc:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "place_scout", "status": "error", "message": "장소 검색 실패"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"장소 검색 중 오류가 발생했습니다: {exc}"},
+            }
 
     async def _handle_save_plan(self, intent: Intent) -> AsyncGenerator[dict, None]:
         yield {

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-04T00:00Z (Evolve #60 — Task #40)
-Run count: 60
+Last run: 2026-04-04T06:20Z (Evolve #61 — Task #41)
+Run count: 61
 Phase: Phase 10: Chat + Multi-Agent Dashboard
 Health: GREEN
 Error Budget: HEALTHY
-Tasks completed: 36
+Tasks completed: 37
 Current focus: Chat + Multi-Agent Dashboard (Phase 10)
-Next planned: #41 - ChatService intent 핸들러 연결
+Next planned: #42 or remaining Phase 9 tasks
 
 ## LTES Snapshot
 
-- Latency: ~15690ms (total run; pytest 1037 tests in 15.69s)
+- Latency: ~16080ms (total run; pytest 1054 tests in 16.08s)
 - Traffic: 1 commit this run
-- Errors: 0 test failures (1037/1037 pass), error_rate=0.0%
-- Saturation: 5 tasks ready
+- Errors: 0 test failures (1054/1054 pass), error_rate=0.0%
+- Saturation: 4 tasks ready
 
 ## Phase Transition
 
@@ -29,6 +29,15 @@ Next planned: #41 - ChatService intent 핸들러 연결
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #61 — 2026-04-04T06:20Z
+- **Task**: #41 - ChatService intent 핸들러 연결 (create_plan → GeminiService, search → SearchService)
+- **Result**: GREEN ✓ (QA pass)
+- **Tests**: 1054/1054 passed (+17 new)
+- **Files changed**: src/app/chat.py (+197/-52), tests/test_chat.py
+- **Builder note**: Intent handlers now call real services via asyncio.to_thread. create_plan→GeminiService.generate_itinerary, search_places→WebSearchService, search_hotels→HotelSearchService, search_flights→FlightSearchService. Services injectable for testability.
+- **LTES**: L=16080ms T=1 commit E=0.0% S=4 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✓ → reporter ✓
 
 ### Evolve Run #60 — 2026-04-04T00:00Z
 - **Task**: #40 - Chat SSE 스트리밍 엔드포인트

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,8 +1,10 @@
-"""Tests for Task #39: ChatService 기본 구조.
+"""Tests for ChatService: 기본 구조 (Task #39) + 서비스 연결 (Task #41).
 
 Done criteria:
 - ChatService가 메시지를 받아 intent JSON을 반환
 - 세션 생성/조회/만료 동작
+- intent에 따라 GeminiService / Search 서비스 호출
+- plan_update, day_update, search_results 이벤트 emit
 - 테스트 통과
 """
 
@@ -11,7 +13,11 @@ import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+from app.ai import AIItineraryResult, AIDayItinerary, AIPlace
 from app.chat import ChatService, Intent, SESSION_TTL_SECONDS
+from app.flight_search import FlightSearchResult, FlightResult
+from app.hotel_search import HotelSearchResult, HotelResult
+from app.web_search import DestinationSearchResult, PlaceSearchResult
 
 
 # ---------------------------------------------------------------------------
@@ -392,3 +398,372 @@ class TestChatSessionEndpoints:
 
         agent_events = [e for e in events if e["type"] == "agent_status"]
         assert agent_events[0]["data"]["agent"] == "coordinator"
+
+
+# ---------------------------------------------------------------------------
+# Task #41: Service handler integration
+# ---------------------------------------------------------------------------
+
+def _make_fake_itinerary() -> AIItineraryResult:
+    return AIItineraryResult(
+        days=[
+            AIDayItinerary(
+                date="2026-05-01",
+                notes="Day 1",
+                places=[
+                    AIPlace(name="Senso-ji", category="sightseeing", estimated_cost=0.0),
+                    AIPlace(name="Ramen Ichiran", category="food", estimated_cost=15.0),
+                ],
+            ),
+            AIDayItinerary(
+                date="2026-05-02",
+                notes="Day 2",
+                places=[
+                    AIPlace(name="Shibuya Crossing", category="sightseeing", estimated_cost=0.0),
+                ],
+            ),
+        ],
+        total_estimated_cost=500.0,
+    )
+
+
+def _make_fake_hotel_result() -> HotelSearchResult:
+    return HotelSearchResult(
+        destination="도쿄",
+        hotels=[
+            HotelResult(name="Hotel A", price_range="$100/night", rating="4.5"),
+            HotelResult(name="Hotel B", price_range="$80/night", rating="4.0"),
+        ],
+    )
+
+
+def _make_fake_flight_result() -> FlightSearchResult:
+    return FlightSearchResult(
+        departure_city="Seoul",
+        arrival_city="도쿄",
+        flights=[
+            FlightResult(airline="Korean Air", price="$300"),
+        ],
+    )
+
+
+def _make_fake_places_result() -> DestinationSearchResult:
+    return DestinationSearchResult(
+        destination="도쿄",
+        query="도쿄 food",
+        places=[
+            PlaceSearchResult(name="Tsukiji Market", category="food"),
+            PlaceSearchResult(name="Harajuku", category="sightseeing"),
+            PlaceSearchResult(name="Akihabara", category="shopping"),
+        ],
+    )
+
+
+class TestServiceHandlerIntegration:
+    """Verify that intent handlers call real services and emit correct events."""
+
+    def _make_service_with_mocks(self, gemini=None, web=None, hotel=None, flight=None):
+        return ChatService(
+            api_key="",
+            ttl_seconds=SESSION_TTL_SECONDS,
+            gemini_service=gemini or MagicMock(),
+            web_search_service=web or MagicMock(),
+            hotel_search_service=hotel or MagicMock(),
+            flight_search_service=flight or MagicMock(),
+        )
+
+    # --- create_plan → GeminiService ---
+
+    def test_create_plan_calls_gemini_generate_itinerary(self):
+        mock_gemini = MagicMock()
+        mock_gemini.generate_itinerary.return_value = _make_fake_itinerary()
+        svc = self._make_service_with_mocks(gemini=mock_gemini)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="create_plan", destination="도쿄",
+            start_date="2026-05-01", end_date="2026-05-02", raw_message="도쿄"
+        )):
+            _collect_events(svc, session.session_id, "도쿄")
+
+        mock_gemini.generate_itinerary.assert_called_once()
+        call_kwargs = mock_gemini.generate_itinerary.call_args
+        assert call_kwargs[0][0] == "도쿄"  # destination
+
+    def test_create_plan_emits_plan_update_event(self):
+        mock_gemini = MagicMock()
+        mock_gemini.generate_itinerary.return_value = _make_fake_itinerary()
+        svc = self._make_service_with_mocks(gemini=mock_gemini)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="create_plan", destination="도쿄", raw_message="도쿄"
+        )):
+            events = _collect_events(svc, session.session_id, "도쿄")
+
+        plan_events = [e for e in events if e["type"] == "plan_update"]
+        assert len(plan_events) == 1
+        assert "days" in plan_events[0]["data"]
+
+    def test_create_plan_emits_day_update_per_day(self):
+        mock_gemini = MagicMock()
+        itinerary = _make_fake_itinerary()
+        mock_gemini.generate_itinerary.return_value = itinerary
+        svc = self._make_service_with_mocks(gemini=mock_gemini)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="create_plan", destination="도쿄", raw_message="도쿄"
+        )):
+            events = _collect_events(svc, session.session_id, "도쿄")
+
+        day_events = [e for e in events if e["type"] == "day_update"]
+        assert len(day_events) == len(itinerary.days)
+
+    def test_create_plan_place_scout_done_has_result_count(self):
+        mock_gemini = MagicMock()
+        mock_gemini.generate_itinerary.return_value = _make_fake_itinerary()
+        svc = self._make_service_with_mocks(gemini=mock_gemini)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="create_plan", destination="도쿄", raw_message="도쿄"
+        )):
+            events = _collect_events(svc, session.session_id, "도쿄")
+
+        scout_done = next(
+            (e for e in events
+             if e["type"] == "agent_status"
+             and e["data"]["agent"] == "place_scout"
+             and e["data"]["status"] == "done"),
+            None,
+        )
+        assert scout_done is not None
+        assert "result_count" in scout_done["data"]
+        assert scout_done["data"]["result_count"] == 3  # 2 + 1 places
+
+    def test_create_plan_gemini_error_emits_planner_error_status(self):
+        mock_gemini = MagicMock()
+        mock_gemini.generate_itinerary.side_effect = RuntimeError("Gemini unavailable")
+        svc = self._make_service_with_mocks(gemini=mock_gemini)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="create_plan", destination="도쿄", raw_message="도쿄"
+        )):
+            events = _collect_events(svc, session.session_id, "도쿄")
+
+        error_events = [
+            e for e in events
+            if e["type"] == "agent_status" and e["data"]["status"] == "error"
+        ]
+        assert len(error_events) >= 1
+        assert error_events[0]["data"]["agent"] == "planner"
+
+    def test_create_plan_with_default_dates_when_missing(self):
+        """When start/end dates are absent, handler should still call Gemini."""
+        mock_gemini = MagicMock()
+        mock_gemini.generate_itinerary.return_value = _make_fake_itinerary()
+        svc = self._make_service_with_mocks(gemini=mock_gemini)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="create_plan", destination="도쿄",
+            start_date=None, end_date=None, raw_message="도쿄"
+        )):
+            _collect_events(svc, session.session_id, "도쿄")
+
+        mock_gemini.generate_itinerary.assert_called_once()
+
+    # --- search_places → WebSearchService ---
+
+    def test_search_places_calls_web_search_service(self):
+        mock_web = MagicMock()
+        mock_web.search_places.return_value = _make_fake_places_result()
+        svc = self._make_service_with_mocks(web=mock_web)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="search_places", destination="도쿄", interests="food", raw_message="도쿄 맛집"
+        )):
+            _collect_events(svc, session.session_id, "도쿄 맛집")
+
+        mock_web.search_places.assert_called_once()
+        args = mock_web.search_places.call_args[0]
+        assert args[0] == "도쿄"
+
+    def test_search_places_emits_search_results_event(self):
+        mock_web = MagicMock()
+        mock_web.search_places.return_value = _make_fake_places_result()
+        svc = self._make_service_with_mocks(web=mock_web)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="search_places", destination="도쿄", raw_message="도쿄"
+        )):
+            events = _collect_events(svc, session.session_id, "도쿄")
+
+        results_events = [e for e in events if e["type"] == "search_results"]
+        assert len(results_events) == 1
+        assert results_events[0]["data"]["type"] == "places"
+
+    def test_search_places_place_scout_done_has_result_count(self):
+        mock_web = MagicMock()
+        mock_web.search_places.return_value = _make_fake_places_result()
+        svc = self._make_service_with_mocks(web=mock_web)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="search_places", destination="도쿄", raw_message="도쿄"
+        )):
+            events = _collect_events(svc, session.session_id, "도쿄")
+
+        scout_done = next(
+            (e for e in events
+             if e["type"] == "agent_status"
+             and e["data"]["agent"] == "place_scout"
+             and e["data"]["status"] == "done"),
+            None,
+        )
+        assert scout_done is not None
+        assert scout_done["data"]["result_count"] == 3
+
+    # --- search_hotels → HotelSearchService ---
+
+    def test_search_hotels_calls_hotel_search_service(self):
+        mock_hotel = MagicMock()
+        mock_hotel.search_hotels.return_value = _make_fake_hotel_result()
+        svc = self._make_service_with_mocks(hotel=mock_hotel)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="search_hotels", destination="도쿄", raw_message="도쿄 호텔"
+        )):
+            _collect_events(svc, session.session_id, "도쿄 호텔")
+
+        mock_hotel.search_hotels.assert_called_once()
+        args = mock_hotel.search_hotels.call_args[0]
+        assert args[0] == "도쿄"
+
+    def test_search_hotels_emits_search_results_event(self):
+        mock_hotel = MagicMock()
+        mock_hotel.search_hotels.return_value = _make_fake_hotel_result()
+        svc = self._make_service_with_mocks(hotel=mock_hotel)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="search_hotels", destination="도쿄", raw_message="도쿄"
+        )):
+            events = _collect_events(svc, session.session_id, "도쿄")
+
+        results_events = [e for e in events if e["type"] == "search_results"]
+        assert len(results_events) == 1
+        assert results_events[0]["data"]["type"] == "hotels"
+
+    def test_search_hotels_hotel_finder_done_has_result_count(self):
+        mock_hotel = MagicMock()
+        mock_hotel.search_hotels.return_value = _make_fake_hotel_result()
+        svc = self._make_service_with_mocks(hotel=mock_hotel)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="search_hotels", destination="도쿄", raw_message="도쿄"
+        )):
+            events = _collect_events(svc, session.session_id, "도쿄")
+
+        finder_done = next(
+            (e for e in events
+             if e["type"] == "agent_status"
+             and e["data"]["agent"] == "hotel_finder"
+             and e["data"]["status"] == "done"),
+            None,
+        )
+        assert finder_done is not None
+        assert finder_done["data"]["result_count"] == 2
+
+    def test_search_hotels_error_emits_hotel_finder_error_status(self):
+        mock_hotel = MagicMock()
+        mock_hotel.search_hotels.side_effect = RuntimeError("hotel search failed")
+        svc = self._make_service_with_mocks(hotel=mock_hotel)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="search_hotels", destination="도쿄", raw_message="도쿄"
+        )):
+            events = _collect_events(svc, session.session_id, "도쿄")
+
+        error_events = [
+            e for e in events
+            if e["type"] == "agent_status" and e["data"]["status"] == "error"
+        ]
+        assert any(e["data"]["agent"] == "hotel_finder" for e in error_events)
+
+    # --- search_flights → FlightSearchService ---
+
+    def test_search_flights_calls_flight_search_service(self):
+        mock_flight = MagicMock()
+        mock_flight.search_flights.return_value = _make_fake_flight_result()
+        svc = self._make_service_with_mocks(flight=mock_flight)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="search_flights", destination="도쿄", raw_message="도쿄 항공"
+        )):
+            _collect_events(svc, session.session_id, "도쿄 항공")
+
+        mock_flight.search_flights.assert_called_once()
+        args = mock_flight.search_flights.call_args[0]
+        assert args[1] == "도쿄"  # arrival_city
+
+    def test_search_flights_emits_search_results_event(self):
+        mock_flight = MagicMock()
+        mock_flight.search_flights.return_value = _make_fake_flight_result()
+        svc = self._make_service_with_mocks(flight=mock_flight)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="search_flights", destination="도쿄", raw_message="도쿄"
+        )):
+            events = _collect_events(svc, session.session_id, "도쿄")
+
+        results_events = [e for e in events if e["type"] == "search_results"]
+        assert len(results_events) == 1
+        assert results_events[0]["data"]["type"] == "flights"
+
+    def test_search_flights_flight_finder_done_has_result_count(self):
+        mock_flight = MagicMock()
+        mock_flight.search_flights.return_value = _make_fake_flight_result()
+        svc = self._make_service_with_mocks(flight=mock_flight)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="search_flights", destination="도쿄", raw_message="도쿄"
+        )):
+            events = _collect_events(svc, session.session_id, "도쿄")
+
+        finder_done = next(
+            (e for e in events
+             if e["type"] == "agent_status"
+             and e["data"]["agent"] == "flight_finder"
+             and e["data"]["status"] == "done"),
+            None,
+        )
+        assert finder_done is not None
+        assert finder_done["data"]["result_count"] == 1
+
+    def test_search_flights_error_emits_flight_finder_error_status(self):
+        mock_flight = MagicMock()
+        mock_flight.search_flights.side_effect = RuntimeError("flight search failed")
+        svc = self._make_service_with_mocks(flight=mock_flight)
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="search_flights", destination="도쿄", raw_message="도쿄"
+        )):
+            events = _collect_events(svc, session.session_id, "도쿄")
+
+        error_events = [
+            e for e in events
+            if e["type"] == "agent_status" and e["data"]["status"] == "error"
+        ]
+        assert any(e["data"]["agent"] == "flight_finder" for e in error_events)


### PR DESCRIPTION
## Evolve Run #61
- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: GREEN
- **Task**: #41 - ChatService intent 핸들러 연결 (create_plan → GeminiService, search → SearchService)
- **QA**: pass
- **Tests**: 1054/1054

Closes #4

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Health GREEN (1037/1037). Selected task #41. |
| 📐 Architect | ⏭️ | Skipped — 5 ready tasks in backlog |
| 🔨 Builder | ✅ | src/app/chat.py (+197/-52), tests/test_chat.py (+17 tests) |
| 🧪 QA | ✅ | 1054/1054 pass, lint clean, done criteria met, no regressions |
| 📝 Reporter | ✅ | This PR |

### Changes
- Intent handlers dispatch to real services via `asyncio.to_thread`
- `create_plan` → `GeminiService.generate_itinerary` (emits `plan_update` + `day_update` per day)
- `search_places` → `WebSearchService.search_places` (emits `search_results`)
- `search_hotels` → `HotelSearchService.search_hotels` (emits `search_results`)
- `search_flights` → `FlightSearchService.search_flights` (emits `search_results`)
- Error paths emit `agent status=error`
- Services injectable via constructor for testability
- 17 new integration tests in `TestServiceHandlerIntegration`

🤖 Auto-generated by Evolve Pipeline