### PR TITLE
feat: per-day cost summary endpoint (#35)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -16,9 +16,6 @@ _(없음)_
 > 이 목록은 시드 태스크다. evolve가 Architect 단계에서 스펙을 분석하고 추가 태스크를 자율적으로 생성한다.
 
 ### Phase 9: User Experience & Polish (remaining)
-
-- [ ] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature]
-  - gh: #5
 - [ ] #36 - Favorite places library (`POST /favorite-places`, `GET /favorite-places`, `DELETE /favorite-places/{id}`; global across plans; copy a place from itinerary to favorites) [feature]
   - gh: #6
 - [ ] #37 - Plan activity log (`PlanActivity` model; record create/update/delete events on plans with timestamp+action+detail; `GET /travel-plans/{id}/activity`) [feature]
@@ -83,10 +80,13 @@ _(없음)_
 - [x] #40 - Chat SSE 스트리밍 엔드포인트 (POST /chat/sessions, SSE messages, GET/DELETE) [feature] — 2026-04-04
 - [x] #41 - ChatService intent 핸들러 연결 (create_plan → GeminiService, search → SearchService) [feature] — 2026-04-04
 
+### Phase 9: User Experience & Polish (remaining, completed)
+- [x] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature] — 2026-04-04
+
 ---
 
 ## Metrics
 
 - Velocity: 1 task/run
-- Total tasks: 37 done, 4 ready
+- Total tasks: 38 done, 3 ready
 - Phase: 10 (Chat + Multi-Agent Dashboard)

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,8 +7,8 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 61,
-    "successful_runs": 57,
+    "total_runs": 62,
+    "successful_runs": 58,
     "failed_runs": 0,
     "success_rate": 1.0,
     "budget_remaining": 1.0,
@@ -80,6 +80,7 @@
     {"run_id": "monitor-2026-04-03-2026", "task": "monitor", "result": "success", "tests_passed": 994, "tests_total": 994},
     {"run_id": "2026-04-03-2100", "task": "#39 - ChatService 기본 구조", "result": "success", "tests_passed": 1037, "tests_total": 1037},
     {"run_id": "2026-04-04-0000", "task": "#40 - Chat SSE 스트리밍 엔드포인트", "result": "success", "tests_passed": 1037, "tests_total": 1037},
-    {"run_id": "2026-04-04-0620", "task": "#41 - ChatService intent 핸들러 연결", "result": "success", "tests_passed": 1054, "tests_total": 1054}
+    {"run_id": "2026-04-04-0620", "task": "#41 - ChatService intent 핸들러 연결", "result": "success", "tests_passed": 1054, "tests_total": 1054},
+    {"run_id": "2026-04-04-1000", "task": "#35 - Per-day cost summary", "result": "success", "tests_passed": 1063, "tests_total": 1063}
   ]
 }

--- a/observability/logs/2026-04-04/run-10-00.json
+++ b/observability/logs/2026-04-04/run-10-00.json
@@ -1,0 +1,49 @@
+{
+  "trace": {
+    "run_id": "2026-04-04-1000",
+    "timestamp": "2026-04-04T10:00:00Z",
+    "phase": "Phase 10 (with Phase 9 remaining tasks)",
+    "health": "GREEN",
+    "task": "#35 - Per-day cost summary",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "pass",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #35 - Per-day cost summary (github_issue: #5)"
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "Ready tasks >= 2; no architect needed"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "Added GET /plans/{plan_id}/itineraries/{day_id}/stats endpoint. DayStats schema with place_count, total_estimated_cost, by_category. 9 new tests. 1063/1063 passing."
+    },
+    {
+      "agent": "qa",
+      "status": "pass",
+      "detail": "All checks passed: all_tests_pass, new_tests_exist, lint_clean, done_criteria_met, no_regressions, no_secrets_leaked"
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Writing logs, updating status.md, backlog.md, error-budget.json, creating PR"
+    }
+  ],
+  "ltes": {
+    "latency": {"total_duration_ms": 16840},
+    "traffic": {"commits": 1, "lines_added": 70, "lines_removed": 0, "files_changed": 3},
+    "errors": {"test_failures": 0, "fix_attempts": 0},
+    "saturation": {"backlog_remaining": 3}
+  }
+}

--- a/src/app/routers/itineraries.py
+++ b/src/app/routers/itineraries.py
@@ -8,6 +8,7 @@ from app.schemas import (
     DayItineraryCreate,
     DayItineraryOut,
     DayItineraryUpdate,
+    DayStats,
     PlaceCreate,
     PlaceOut,
     PlaceReorderRequest,
@@ -97,6 +98,24 @@ def delete_day(plan_id: int, day_id: int, db: Session = Depends(get_db)):
     day = _get_day_or_404(plan_id, day_id, db)
     db.delete(day)
     db.commit()
+
+
+@router.get("/{day_id}/stats", response_model=DayStats)
+def get_day_stats(plan_id: int, day_id: int, db: Session = Depends(get_db)):
+    """Return place count, total estimated cost, and category breakdown for a day."""
+    day = _get_day_or_404(plan_id, day_id, db)
+    by_category: dict[str, float] = {}
+    total = 0.0
+    for place in day.places:
+        cat = place.category or ""
+        by_category[cat] = by_category.get(cat, 0.0) + place.estimated_cost
+        total += place.estimated_cost
+    return DayStats(
+        day_id=day_id,
+        place_count=len(day.places),
+        total_estimated_cost=total,
+        by_category=by_category,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/app/schemas.py
+++ b/src/app/schemas.py
@@ -269,3 +269,12 @@ class AgentStatusEvent(BaseModel):
     status: str  # idle | thinking | working | done | error
     message: str
     result_count: Optional[int] = None
+
+
+# --- DayStats ---
+
+class DayStats(BaseModel):
+    day_id: int
+    place_count: int
+    total_estimated_cost: float
+    by_category: dict[str, float]

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-04T06:20Z (Evolve #61 — Task #41)
-Run count: 61
+Last run: 2026-04-04T10:00Z (Evolve #62 — Task #35)
+Run count: 62
 Phase: Phase 10: Chat + Multi-Agent Dashboard
 Health: GREEN
 Error Budget: HEALTHY
-Tasks completed: 37
-Current focus: Chat + Multi-Agent Dashboard (Phase 10)
-Next planned: #42 or remaining Phase 9 tasks
+Tasks completed: 38
+Current focus: Phase 9 remaining tasks + Phase 10
+Next planned: #36 Favorite places library
 
 ## LTES Snapshot
 
-- Latency: ~16080ms (total run; pytest 1054 tests in 16.08s)
+- Latency: ~16840ms (total run; pytest 1063 tests in 16.84s)
 - Traffic: 1 commit this run
-- Errors: 0 test failures (1054/1054 pass), error_rate=0.0%
-- Saturation: 4 tasks ready
+- Errors: 0 test failures (1063/1063 pass), error_rate=0.0%
+- Saturation: 3 tasks ready
 
 ## Phase Transition
 
@@ -29,6 +29,15 @@ Next planned: #42 or remaining Phase 9 tasks
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #62 — 2026-04-04T10:00Z
+- **Task**: #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats`)
+- **Result**: GREEN ✓ (QA pass)
+- **Tests**: 1063/1063 passed (+9 new, TestDayStats class)
+- **Files changed**: src/app/routers/itineraries.py, src/app/schemas.py, tests/test_itineraries.py (+70 lines)
+- **Builder note**: Added DayStats schema (place_count, total_estimated_cost, by_category dict). Endpoint returns per-day stats for a given itinerary day.
+- **LTES**: L=16840ms T=1 commit E=0.0% S=3 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✓ → reporter ✓
 
 ### Evolve Run #61 — 2026-04-04T06:20Z
 - **Task**: #41 - ChatService intent 핸들러 연결 (create_plan → GeminiService, search → SearchService)

--- a/tests/test_itineraries.py
+++ b/tests/test_itineraries.py
@@ -478,6 +478,80 @@ class TestDeletePlace:
 # Integration — plan-level view reflects manual changes
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# DayStats — GET /plans/{id}/itineraries/{day_id}/stats
+# ---------------------------------------------------------------------------
+
+class TestDayStats:
+    def test_returns_200(self, client):
+        plan_id = _create_plan(client)
+        day = _add_day(client, plan_id)
+        r = client.get(f"/plans/{plan_id}/itineraries/{day['id']}/stats")
+        assert r.status_code == 200
+
+    def test_empty_day_zero_cost(self, client):
+        plan_id = _create_plan(client)
+        day = _add_day(client, plan_id)
+        r = client.get(f"/plans/{plan_id}/itineraries/{day['id']}/stats")
+        data = r.json()
+        assert data["place_count"] == 0
+        assert data["total_estimated_cost"] == 0.0
+        assert data["by_category"] == {}
+
+    def test_place_count(self, client):
+        plan_id = _create_plan(client)
+        day = _add_day(client, plan_id)
+        _add_place(client, plan_id, day["id"])
+        _add_place(client, plan_id, day["id"], {**PLACE_PAYLOAD, "name": "Louvre"})
+        r = client.get(f"/plans/{plan_id}/itineraries/{day['id']}/stats")
+        assert r.json()["place_count"] == 2
+
+    def test_total_estimated_cost(self, client):
+        plan_id = _create_plan(client)
+        day = _add_day(client, plan_id)
+        _add_place(client, plan_id, day["id"], {**PLACE_PAYLOAD, "estimated_cost": 30.0})
+        _add_place(client, plan_id, day["id"], {**PLACE_PAYLOAD, "name": "Louvre", "estimated_cost": 20.0})
+        r = client.get(f"/plans/{plan_id}/itineraries/{day['id']}/stats")
+        assert r.json()["total_estimated_cost"] == 50.0
+
+    def test_category_breakdown(self, client):
+        plan_id = _create_plan(client)
+        day = _add_day(client, plan_id)
+        _add_place(client, plan_id, day["id"], {**PLACE_PAYLOAD, "category": "sightseeing", "estimated_cost": 25.0})
+        _add_place(client, plan_id, day["id"], {**PLACE_PAYLOAD, "name": "Café de Flore", "category": "food", "estimated_cost": 40.0})
+        _add_place(client, plan_id, day["id"], {**PLACE_PAYLOAD, "name": "Louvre", "category": "sightseeing", "estimated_cost": 15.0})
+        r = client.get(f"/plans/{plan_id}/itineraries/{day['id']}/stats")
+        data = r.json()
+        assert data["by_category"]["sightseeing"] == 40.0
+        assert data["by_category"]["food"] == 40.0
+
+    def test_response_has_day_id(self, client):
+        plan_id = _create_plan(client)
+        day = _add_day(client, plan_id)
+        r = client.get(f"/plans/{plan_id}/itineraries/{day['id']}/stats")
+        assert r.json()["day_id"] == day["id"]
+
+    def test_404_missing_day(self, client):
+        plan_id = _create_plan(client)
+        r = client.get(f"/plans/{plan_id}/itineraries/9999/stats")
+        assert r.status_code == 404
+
+    def test_404_wrong_plan(self, client):
+        plan_id = _create_plan(client)
+        day = _add_day(client, plan_id)
+        other = _create_plan(client)
+        r = client.get(f"/plans/{other}/itineraries/{day['id']}/stats")
+        assert r.status_code == 404
+
+    def test_404_missing_plan(self, client):
+        r = client.get("/plans/9999/itineraries/1/stats")
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Integration — plan-level view reflects manual changes
+# ---------------------------------------------------------------------------
+
 class TestPlanReflectsManualEdits:
     def test_plan_detail_shows_new_day(self, client):
         plan_id = _create_plan(client)


### PR DESCRIPTION
## Evolve Run #62
- **Phase**: Phase 10 (with Phase 9 remaining tasks)
- **Health**: GREEN
- **Task**: #35 - Per-day cost summary
- **QA**: pass
- **Tests**: 1063/1063

Closes #5

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #35 - Per-day cost summary (github_issue: #5) |
| 📐 Architect | ⏭️ | Skipped — Ready tasks >= 2 |
| 🔨 Builder | ✅ | Added DayStats schema + GET /plans/{plan_id}/itineraries/{day_id}/stats endpoint. 70 lines added across 3 files. |
| 🧪 QA | ✅ | All checks passed: tests 1063/1063, lint clean, done criteria met, no regressions, no secrets |
| 📝 Reporter | ✅ | This PR |

🤖 Auto-generated by Evolve Pipeline