### PR TITLE
feat: Secretary save_plan handler: persist plan to DB (#48)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -12,13 +12,6 @@ _(없음)_
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
 
-- [ ] #48 - Secretary save_plan handler: persist plan to DB [feature]
-  - ref: markdowns/feat-chat-dashboard.md (Stage 4 — 저장)
-  - depends: #46
-  - files: src/app/chat.py, src/app/schemas.py, tests/test_chat.py
-  - done: `_handle_save_plan` creates TravelPlan DB record; plan_saved event includes plan_id; test_plan_save_persists_to_db + test_plan_saved_event_includes_plan_id pass
-  - gh: #24
-
 - [ ] #49 - E2E Playwright tests for chat page [test]
   - ref: markdowns/feat-chat-dashboard.md (Test Cases — e2e/chat.spec.ts)
   - depends: #45
@@ -105,6 +98,7 @@ _(없음)_
 - [x] #45 - Agent panel compact/expanded toggle + mobile responsive layout [feature] — 2026-04-04
 - [x] #46 - SSE reconnect with exponential backoff + session state restore on reconnect [feature] — 2026-04-04
 - [x] #47 - modify_day intent handler: update a day's places via chat [feature] — 2026-04-04
+- [x] #48 - Secretary save_plan handler: persist plan to DB [feature] — 2026-04-04
 
 ### Phase 9: User Experience & Polish (remaining, completed)
 - [x] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature] — 2026-04-04
@@ -116,5 +110,5 @@ _(없음)_
 ## Metrics
 
 - Velocity: 1 task/run
-- Total tasks: 46 done, 5 ready
+- Total tasks: 47 done, 4 ready
 - Phase: 10 (Chat + Multi-Agent Dashboard)

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,11 +1,11 @@
 {
-  "last_updated": "2026-04-04T31:00Z",
+  "last_updated": "2026-04-04T32:00Z",
   "summary": {
-    "total_runs": 72,
-    "total_commits": 76,
-    "total_tests": 1177,
-    "tasks_completed": 46,
-    "tasks_remaining": 5,
+    "total_runs": 73,
+    "total_commits": 77,
+    "total_tests": 1179,
+    "tasks_completed": 47,
+    "tasks_remaining": 4,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
     "health": "GREEN"
   },
@@ -39,11 +39,11 @@
     },
     {
       "date": "2026-04-04",
-      "runs": 12,
-      "tasks_completed": 11,
-      "tests_passed": 1177,
+      "runs": 13,
+      "tasks_completed": 12,
+      "tests_passed": 1179,
       "tests_failed": 0,
-      "commits": 24,
+      "commits": 25,
       "health": "GREEN"
     }
   ],

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,8 +7,8 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 72,
-    "successful_runs": 67,
+    "total_runs": 73,
+    "successful_runs": 68,
     "failed_runs": 0,
     "success_rate": 1.0,
     "budget_remaining": 1.0,
@@ -91,6 +91,7 @@
     {"run_id": "monitor-2026-04-04-1336", "task": "monitor", "result": "success", "tests_passed": 1153, "tests_total": 1153},
     {"run_id": "2026-04-04-2800", "task": "#46 - SSE reconnect with exponential backoff + session state restore on reconnect", "result": "success", "tests_passed": 1170, "tests_total": 1170},
     {"run_id": "2026-04-04-3000", "task": "#47 - modify_day intent handler: update a day's places via chat", "result": "success", "tests_passed": 1177, "tests_total": 1177},
-    {"run_id": "monitor-2026-04-04-3100", "task": "monitor", "result": "success", "tests_passed": 1177, "tests_total": 1177}
+    {"run_id": "monitor-2026-04-04-3100", "task": "monitor", "result": "success", "tests_passed": 1177, "tests_total": 1177},
+    {"run_id": "2026-04-04-3200", "task": "#48 - Secretary save_plan handler: persist plan to DB", "result": "success", "tests_passed": 1179, "tests_total": 1179}
   ]
 }

--- a/observability/logs/2026-04-04/run-32-00.json
+++ b/observability/logs/2026-04-04/run-32-00.json
@@ -1,0 +1,29 @@
+{
+  "trace": {
+    "run_id": "2026-04-04-3200",
+    "timestamp": "2026-04-04T32:00Z",
+    "phase": "Phase 10",
+    "health": "GREEN",
+    "task": "#48 - Secretary save_plan handler: persist plan to DB",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "pass",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {"agent": "coordinator", "status": "completed", "detail": "Selected task #48, no fix/architect needed"},
+    {"agent": "architect", "status": "skipped", "detail": "backlog_ready_count=4 >= 2, skipped"},
+    {"agent": "builder", "status": "completed", "detail": "_handle_save_plan accepts (intent, session, db); inserts TravelPlan row; plan_saved event includes plan_id; process_message gains optional db= param; router injects Depends(get_db); 2 new tests added"},
+    {"agent": "qa", "status": "pass", "detail": "1179/1179 passed; lint clean; done_criteria met; no regressions; no secrets"},
+    {"agent": "reporter", "status": "running", "detail": "Writing logs, updating status files, creating PR"}
+  ],
+  "ltes": {
+    "latency": {"total_duration_ms": 21810},
+    "traffic": {"commits": 1, "lines_added": 95, "lines_removed": 12, "files_changed": 3},
+    "errors": {"test_failures": 0, "fix_attempts": 0},
+    "saturation": {"backlog_remaining": 4}
+  }
+}

--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -3,7 +3,7 @@
 import asyncio
 import uuid
 from datetime import date, datetime, timedelta, timezone
-from typing import AsyncGenerator, Optional
+from typing import TYPE_CHECKING, AsyncGenerator, Optional
 
 from google import genai
 from google.genai import types
@@ -14,6 +14,9 @@ from app.config import GEMINI_API_KEY
 from app.flight_search import FlightSearchService
 from app.hotel_search import HotelSearchService
 from app.web_search import WebSearchService
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 SESSION_TTL_SECONDS = 1800  # 30 minutes
 
@@ -140,6 +143,7 @@ Return a JSON object with these fields:
         self,
         session_id: str,
         message: str,
+        db: Optional["Session"] = None,
     ) -> AsyncGenerator[dict, None]:
         """Process a user message and yield SSE event dicts."""
         session = self.get_session(session_id)
@@ -195,7 +199,7 @@ Return a JSON object with these fields:
             async for event in self._handle_modify_day(intent, session):
                 yield _track(event)
         elif intent.action == "save_plan":
-            async for event in self._handle_save_plan(intent):
+            async for event in self._handle_save_plan(intent, session, db):
                 yield _track(event)
         else:
             yield {
@@ -523,19 +527,67 @@ Return a JSON object with these fields:
                 "data": {"text": f"일정 수정 중 오류가 발생했습니다: {exc}"},
             }
 
-    async def _handle_save_plan(self, intent: Intent) -> AsyncGenerator[dict, None]:
+    async def _handle_save_plan(
+        self,
+        intent: Intent,
+        session: "ChatSession",
+        db: Optional["Session"] = None,
+    ) -> AsyncGenerator[dict, None]:
         yield {
             "type": "agent_status",
             "data": {"agent": "secretary", "status": "working", "message": "여행 계획 저장 중..."},
         }
         await asyncio.sleep(0)
+
+        plan_id: Optional[int] = None
+        if db is not None:
+            from app.models import TravelPlan as TravelPlanModel
+
+            last_plan = session.last_plan
+            if last_plan:
+                dest = last_plan.get("destination", intent.destination or "여행 계획")
+                start_str = last_plan.get("start_date")
+                end_str = last_plan.get("end_date")
+                budget = last_plan.get("budget", intent.budget or 2000.0)
+                interests = last_plan.get("interests", intent.interests or "")
+            else:
+                dest = intent.destination or "여행 계획"
+                start, end = self._parse_dates(intent)
+                start_str = start.isoformat()
+                end_str = end.isoformat()
+                budget = intent.budget or 2000.0
+                interests = intent.interests or ""
+
+            try:
+                start_date = date.fromisoformat(start_str) if start_str else date.today()
+            except ValueError:
+                start_date = date.today()
+            try:
+                end_date = date.fromisoformat(end_str) if end_str else start_date
+            except ValueError:
+                end_date = start_date
+            if end_date < start_date:
+                end_date = start_date
+
+            plan_record = TravelPlanModel(
+                destination=dest,
+                start_date=start_date,
+                end_date=end_date,
+                budget=float(budget),
+                interests=interests if isinstance(interests, str) else "",
+            )
+            db.add(plan_record)
+            db.commit()
+            db.refresh(plan_record)
+            plan_id = plan_record.id
+
         yield {
             "type": "agent_status",
             "data": {"agent": "secretary", "status": "done", "message": "저장 완료!"},
         }
         yield {
             "type": "plan_saved",
-            "data": {"message": "여행 계획이 저장되었습니다."},
+            "data": {"message": "여행 계획이 저장되었습니다.", "plan_id": plan_id},
         }
         yield {
             "type": "chat_chunk",

--- a/src/app/routers/chat.py
+++ b/src/app/routers/chat.py
@@ -3,10 +3,12 @@
 import json
 from typing import AsyncGenerator
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
 
 from app.chat import chat_service
+from app.database import get_db
 from app.schemas import ChatMessageRequest, ChatSessionOut
 
 router = APIRouter(prefix="/chat", tags=["chat"])
@@ -49,14 +51,18 @@ def delete_session(session_id: str):
 
 
 @router.post("/sessions/{session_id}/messages")
-async def send_message(session_id: str, payload: ChatMessageRequest):
+async def send_message(
+    session_id: str,
+    payload: ChatMessageRequest,
+    db: Session = Depends(get_db),
+):
     """Send a user message; returns an SSE stream of agent events."""
     session = chat_service.get_session(session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found or expired")
 
     async def event_stream() -> AsyncGenerator[str, None]:
-        async for event in chat_service.process_message(session_id, payload.message):
+        async for event in chat_service.process_message(session_id, payload.message, db=db):
             yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
 
     return StreamingResponse(

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-04T31:00Z (Monitor — health check)
-Run count: 72
+Last run: 2026-04-04T32:00Z (Evolve Run #71 — #48 Secretary save_plan handler)
+Run count: 73
 Phase: Phase 10: Chat + Multi-Agent Dashboard
 Health: GREEN
 Error Budget: HEALTHY
-Tasks completed: 46
+Tasks completed: 47
 Current focus: Phase 10 (Chat + Multi-Agent Dashboard)
-Next planned: #48 Secretary save_plan handler
+Next planned: #49 E2E Playwright tests for chat page
 
 ## LTES Snapshot
 
-- Latency: ~20480ms (pytest 1177 tests in 20.48s)
-- Traffic: 24 commits/24h
-- Errors: 0 test failures (1177/1177 pass), error_rate=0.0%
-- Saturation: 5 tasks ready
+- Latency: ~21810ms (pytest 1179 tests in 21.81s)
+- Traffic: 25 commits/24h
+- Errors: 0 test failures (1179/1179 pass), error_rate=0.0%
+- Saturation: 4 tasks ready
 
 ## Phase Transition
 
@@ -29,6 +29,15 @@ Next planned: #48 Secretary save_plan handler
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #71 — 2026-04-04T32:00Z
+- **Task**: #48 - Secretary save_plan handler: persist plan to DB
+- **Result**: GREEN ✓ (QA pass)
+- **Tests**: 1179/1179 passed (+2 new: test_plan_save_persists_to_db, test_plan_saved_event_includes_plan_id)
+- **Files changed**: src/app/chat.py, src/app/routers/chat.py, tests/test_chat.py
+- **Builder note**: _handle_save_plan now accepts (intent, session, db) — when db is provided it inserts a TravelPlan row from session.last_plan (or intent fields as fallback) and returns plan_id in the plan_saved event. process_message gains optional db= param passed through to _handle_save_plan. Router injects Depends(get_db) and forwards db to process_message.
+- **LTES**: L=21810ms T=1 commit E=0.0% S=4 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✓ → reporter ✓
 
 ### Monitor — 2026-04-04T31:00Z
 - **Task**: health check

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1008,3 +1008,101 @@ class TestModifyDay:
             and e["data"]["status"] == "error"
         ]
         assert len(error_events) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Task #48: Secretary save_plan handler — persist plan to DB
+# ---------------------------------------------------------------------------
+
+def _make_test_db():
+    """Return a (engine, Session) pair backed by an in-memory SQLite DB."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+    from app.database import Base
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestingSession = sessionmaker(bind=engine)
+    return engine, TestingSession
+
+
+def _collect_events_with_db(svc, session_id, message, db):
+    """Collect all events from process_message, passing a DB session."""
+    async def _run():
+        events = []
+        async for event in svc.process_message(session_id, message, db=db):
+            events.append(event)
+        return events
+
+    return asyncio.run(_run())
+
+
+class TestSavePlanPersistence:
+    """_handle_save_plan must create a TravelPlan DB record and include plan_id in plan_saved event."""
+
+    def test_plan_save_persists_to_db(self):
+        """save_plan intent creates a TravelPlan row in the database."""
+        from app.database import Base
+        from app.models import TravelPlan as TravelPlanModel
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_plan = {
+                "destination": "도쿄",
+                "start_date": "2026-05-01",
+                "end_date": "2026-05-04",
+                "budget": 2000000.0,
+                "interests": "food",
+            }
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="save_plan", raw_message="저장해줘"
+            )):
+                _collect_events_with_db(svc, session.session_id, "저장해줘", db)
+
+            plans = db.query(TravelPlanModel).all()
+            assert len(plans) == 1
+            assert plans[0].destination == "도쿄"
+            assert plans[0].budget == 2000000.0
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)
+
+    def test_plan_saved_event_includes_plan_id(self):
+        """plan_saved SSE event must include a non-None plan_id after DB insert."""
+        from app.database import Base
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_plan = {
+                "destination": "파리",
+                "start_date": "2026-06-01",
+                "end_date": "2026-06-05",
+                "budget": 1500000.0,
+                "interests": "",
+            }
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="save_plan", raw_message="저장"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "저장", db)
+
+            saved_events = [e for e in events if e["type"] == "plan_saved"]
+            assert len(saved_events) == 1
+            assert "plan_id" in saved_events[0]["data"]
+            assert saved_events[0]["data"]["plan_id"] is not None
+            assert isinstance(saved_events[0]["data"]["plan_id"], int)
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)


### PR DESCRIPTION
## Evolve Run #71
- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: GREEN
- **Task**: #48 - Secretary save_plan handler: persist plan to DB
- **QA**: pass
- **Tests**: 1179/1179

Closes #24

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #48, no fix/architect needed |
| 📐 Architect | ⏭️ | Skipped (backlog_ready_count=4 ≥ 2) |
| 🔨 Builder | ✅ | src/app/chat.py, src/app/routers/chat.py, tests/test_chat.py (+95/-12 lines) |
| 🧪 QA | ✅ | 1179/1179 pass, lint clean, done_criteria met, no regressions |
| 📝 Reporter | ✅ | This PR |

### Changes
- `_handle_save_plan` now accepts `(intent, session, db)` — when `db` is provided it inserts a `TravelPlan` row from `session.last_plan` (or intent fields as fallback) and returns `plan_id` in the `plan_saved` event
- `process_message` gains optional `db=` parameter passed through to `_handle_save_plan`
- Router `send_message` injects `Depends(get_db)` and forwards `db` to `process_message`
- New tests: `test_plan_save_persists_to_db` and `test_plan_saved_event_includes_plan_id`

🤖 Auto-generated by Evolve Pipeline