### PR TITLE
infra: Reporter agent auto-close GitHub Issues on task completion (#51)

### DIFF
--- a/.claude/agents/reporter.md
+++ b/.claude/agents/reporter.md
@@ -136,8 +136,18 @@ git checkout main
 ```
 
 ### 7.5 GitHub Issue 업데이트
-- **QA pass**: Issue가 있으면 PR의 `Closes #N`으로 자동 close됨 (별도 작업 불필요)
-- **QA fail**: Issue에 실패 코멘트 추가
+- **QA pass**: Issue가 있으면 명시적으로 close하고, PR body의 `Closes #N`으로도 머지 시 자동 close됨
+```bash
+if [ -n "$GITHUB_ISSUE" ]; then
+  gh issue close "$GITHUB_ISSUE" --comment "✅ **Completed** (Run #<N>)
+
+이 태스크는 QA를 통과하여 PR에서 구현되었습니다.
+- **Tests**: <passed>/<total> passed
+
+🤖 Auto-closed by Reporter Agent"
+fi
+```
+- **QA fail**: Issue에 실패 코멘트 추가 (close하지 않음)
 ```bash
 gh issue comment <issue-number> --body "🧪 **QA Failed** (Run #<N>)
 

--- a/backlog.md
+++ b/backlog.md
@@ -11,12 +11,35 @@ _(없음)_
 ## Ready (우선순위 순)
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
+- [ ] #52 - Chat Secretary: export_calendar intent handler [feature]
+  - ref: markdowns/feat-chat-dashboard.md (Secretary role: 저장, 캘린더 내보내기)
+  - files: src/app/chat.py, tests/test_chat.py
+  - done: `export_calendar` intent extracted; Secretary agent emits thinking→working→done; calls calendar service; emits chat_chunk with confirmation
+  - gh: #33
 
-- [ ] #51 - Reporter agent: auto-close GitHub Issues on task completion [infra]
-  - ref: markdowns/feat-dynamic-repo.md (Phase 1 — Reporter issue close)
+- [ ] #53 - Chat conversation context: pass last 10 messages to Gemini [improvement]
+  - ref: markdowns/feat-chat-dashboard.md (ChatService architecture)
+  - files: src/app/chat.py, tests/test_chat.py
+  - done: ChatSession stores message_history (max 10 turns); history passed to Gemini calls; follow-up messages infer prior context correctly
+  - gh: #34
+
+- [ ] #56 - Chat: list_plans intent handler — show saved plans in chat [feature]
+  - ref: CLAUDE.md (User Story #2: plan CRUD)
+  - files: src/app/chat.py, tests/test_chat.py
+  - done: `list_plans` intent extracted; `_handle_list_plans()` queries DB; emits chat_chunk with formatted plan list; secretary agent status events emitted
+  - gh: #37
+
+- [ ] #54 - Coordinator agent: gh issue comment on task assignment [infra]
+  - ref: markdowns/feat-dynamic-repo.md (Coordinator Agent 변경)
+  - files: .claude/agents/coordinator.md
+  - done: coordinator.md includes `gh issue comment` step after handoff.json write; skips gracefully if no gh issue
+  - gh: #35
+
+- [ ] #55 - Incident auto-issue: create Bug GitHub Issue on 3 consecutive QA failures [infra]
+  - ref: markdowns/feat-dynamic-repo.md (Error / Incident section)
   - files: .claude/agents/reporter.md
-  - done: reporter.md includes step to `gh issue close <number>` and `Closes #<number>` in PR body
-  - gh: #27
+  - done: reporter.md checks qa-result.json failure count; creates `bug,blocked` Issue on ≥3 failures with failure details; skips if open bug already exists
+  - gh: #36
 
 ### Phase 9: User Experience & Polish (remaining)
 - [ ] #38 - Bulk expense import via JSON (`POST /plans/{id}/expenses/bulk`; accepts list of ExpenseCreate; atomic — all or nothing; returns created list + count) [feature]
@@ -87,6 +110,7 @@ _(없음)_
 - [x] #48 - Secretary save_plan handler: persist plan to DB [feature] — 2026-04-04
 - [x] #49 - E2E Playwright tests for chat page [test] — 2026-04-04
 - [x] #50 - Budget Analyst: real per-category cost breakdown in chat [feature] — 2026-04-04
+- [x] #51 - Reporter agent: auto-close GitHub Issues on task completion [infra] — 2026-04-04
 
 ### Phase 9: User Experience & Polish (remaining, completed)
 - [x] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature] — 2026-04-04
@@ -98,5 +122,5 @@ _(없음)_
 ## Metrics
 
 - Velocity: 1 task/run
-- Total tasks: 49 done, 2 ready
+- Total tasks: 50 done, 6 ready
 - Phase: 10 (Chat + Multi-Agent Dashboard)

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,11 +1,11 @@
 {
-  "last_updated": "2026-04-04T36:00Z",
+  "last_updated": "2026-04-04T38:00Z",
   "summary": {
-    "total_runs": 76,
-    "total_commits": 79,
+    "total_runs": 77,
+    "total_commits": 80,
     "total_tests": 1181,
-    "tasks_completed": 49,
-    "tasks_remaining": 2,
+    "tasks_completed": 50,
+    "tasks_remaining": 6,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
     "health": "GREEN"
   },
@@ -39,11 +39,11 @@
     },
     {
       "date": "2026-04-04",
-      "runs": 16,
-      "tasks_completed": 14,
+      "runs": 17,
+      "tasks_completed": 15,
       "tests_passed": 1181,
       "tests_failed": 0,
-      "commits": 27,
+      "commits": 28,
       "health": "GREEN"
     }
   ],

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,8 +7,8 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 76,
-    "successful_runs": 71,
+    "total_runs": 77,
+    "successful_runs": 72,
     "failed_runs": 0,
     "success_rate": 1.0,
     "budget_remaining": 1.0,
@@ -95,6 +95,7 @@
     {"run_id": "2026-04-04-3200", "task": "#48 - Secretary save_plan handler: persist plan to DB", "result": "success", "tests_passed": 1179, "tests_total": 1179},
     {"run_id": "2026-04-04-3400", "task": "#49 - E2E Playwright tests for chat page", "result": "success", "tests_passed": 1179, "tests_total": 1179},
     {"run_id": "monitor-2026-04-04-3500", "task": "monitor", "result": "success", "tests_passed": 1179, "tests_total": 1179},
-    {"run_id": "2026-04-04-3600", "task": "#50 - Budget Analyst: real per-category cost breakdown in chat", "result": "success", "tests_passed": 1181, "tests_total": 1181}
+    {"run_id": "2026-04-04-3600", "task": "#50 - Budget Analyst: real per-category cost breakdown in chat", "result": "success", "tests_passed": 1181, "tests_total": 1181},
+    {"run_id": "2026-04-04-3800", "task": "#51 - Reporter agent: auto-close GitHub Issues on task completion", "result": "success", "tests_passed": 1181, "tests_total": 1181}
   ]
 }

--- a/observability/logs/2026-04-04/run-38-00.json
+++ b/observability/logs/2026-04-04/run-38-00.json
@@ -1,0 +1,49 @@
+{
+  "trace": {
+    "run_id": "2026-04-04-3800",
+    "timestamp": "2026-04-04T38:00Z",
+    "phase": "Phase 10",
+    "health": "GREEN",
+    "task": "#51 - Reporter agent: auto-close GitHub Issues on task completion",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "completed",
+      "builder": "completed",
+      "qa": "pass",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "summary": "Health GREEN (1181/1181 tests). Selected task #51: Reporter agent auto-close GitHub Issues. needs_architect=true."
+    },
+    {
+      "agent": "architect",
+      "status": "completed",
+      "summary": "Task #51 planned: update reporter.md section 7.5 with explicit gh issue close command on QA pass."
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "summary": "Updated .claude/agents/reporter.md: added explicit gh issue close $GITHUB_ISSUE step in section 7.5 for QA pass case. +12/-3 lines."
+    },
+    {
+      "agent": "qa",
+      "status": "pass",
+      "summary": "All checks pass: 1181/1181 tests, lint clean, done_criteria met (gh issue close + Closes #N in PR body), no regressions, no secrets."
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "summary": "Writing logs, updating status.md/backlog.md/error-budget.json, creating PR."
+    }
+  ],
+  "ltes": {
+    "latency": {"total_duration_ms": 18840},
+    "traffic": {"commits": 1, "lines_added": 12, "lines_removed": 3, "files_changed": 1},
+    "errors": {"test_failures": 0, "fix_attempts": 0},
+    "saturation": {"backlog_remaining": 6}
+  }
+}

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-04T36:00Z (Evolve Run #73 — #50 Budget Analyst cost breakdown)
-Run count: 76
+Last run: 2026-04-04T38:00Z (Evolve Run #74 — #51 Reporter agent: auto-close GitHub Issues)
+Run count: 77
 Phase: Phase 10: Chat + Multi-Agent Dashboard
 Health: GREEN
 Error Budget: HEALTHY
-Tasks completed: 49
+Tasks completed: 50
 Current focus: Phase 10 (Chat + Multi-Agent Dashboard)
-Next planned: #51 Reporter agent: auto-close GitHub Issues on task completion
+Next planned: #52 Chat Secretary: export_calendar intent handler
 
 ## LTES Snapshot
 
-- Latency: ~19060ms (pytest 1181 tests in 19.06s)
-- Traffic: 26 commits/24h
+- Latency: ~18840ms (pytest 1181 tests in 18.84s)
+- Traffic: 28 commits/24h
 - Errors: 0 test failures (1181/1181 pass), error_rate=0.0%
-- Saturation: 2 tasks ready
+- Saturation: 6 tasks ready
 
 ## Phase Transition
 
@@ -29,6 +29,15 @@ Next planned: #51 Reporter agent: auto-close GitHub Issues on task completion
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #74 — 2026-04-04T38:00Z
+- **Task**: #51 - Reporter agent: auto-close GitHub Issues on task completion
+- **Result**: GREEN ✓ (QA pass)
+- **Tests**: 1181/1181 passed (no change — infra task, no source code changes)
+- **Files changed**: .claude/agents/reporter.md (+12/-3)
+- **Builder note**: Updated reporter.md section 7.5 with explicit `gh issue close "$GITHUB_ISSUE"` command when QA passes. The `Closes #<issue>` in PR body via ISSUE_REF variable was already present. Both done criteria confirmed: (1) explicit gh issue close step, (2) Closes #N in PR body.
+- **LTES**: L=18840ms T=1 commit E=0.0% S=6 tasks remaining
+- **Agents**: coordinator ✓ → architect ✓ → builder ✓ → qa ✓ → reporter ✓
 
 ### Evolve Run #73 — 2026-04-04T36:00Z
 - **Task**: #50 - Budget Analyst: real per-category cost breakdown in chat


### PR DESCRIPTION
## Evolve Run #74
- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: GREEN
- **Task**: #51 - Reporter agent: auto-close GitHub Issues on task completion
- **QA**: pass
- **Tests**: 1181/1181

Closes #27

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Health GREEN (1181/1181). Selected task #51. needs_architect=true. |
| 📐 Architect | ✅ | Planned: update reporter.md section 7.5 with explicit gh issue close command on QA pass. |
| 🔨 Builder | ✅ | .claude/agents/reporter.md (+12/-3): added explicit `gh issue close "$GITHUB_ISSUE"` in section 7.5 for QA pass. Closes #N in PR body via ISSUE_REF already present. |
| 🧪 QA | ✅ | All checks pass: 1181/1181 tests, lint clean, done_criteria met, no regressions, no secrets. |
| 📝 Reporter | ✅ | This PR |

🤖 Auto-generated by Evolve Pipeline