### PR TITLE
improvement: Chat conversation context — pass last 10 messages to Gemini (#53)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -12,12 +12,6 @@ _(없음)_
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
 
-- [ ] #53 - Chat conversation context: pass last 10 messages to Gemini [improvement]
-  - ref: markdowns/feat-chat-dashboard.md (ChatService architecture)
-  - files: src/app/chat.py, tests/test_chat.py
-  - done: ChatSession stores message_history (max 10 turns); history passed to Gemini calls; follow-up messages infer prior context correctly
-  - gh: #34
-
 - [ ] #56 - Chat: list_plans intent handler — show saved plans in chat [feature]
   - ref: CLAUDE.md (User Story #2: plan CRUD)
   - files: src/app/chat.py, tests/test_chat.py
@@ -107,6 +101,7 @@ _(없음)_
 - [x] #50 - Budget Analyst: real per-category cost breakdown in chat [feature] — 2026-04-04
 - [x] #51 - Reporter agent: auto-close GitHub Issues on task completion [infra] — 2026-04-04
 - [x] #52 - Chat Secretary: export_calendar intent handler [feature] — 2026-04-04
+- [x] #53 - Chat conversation context: pass last 10 messages to Gemini [improvement] — 2026-04-04
 
 ### Phase 9: User Experience & Polish (remaining, completed)
 - [x] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature] — 2026-04-04
@@ -118,5 +113,5 @@ _(없음)_
 ## Metrics
 
 - Velocity: 1 task/run
-- Total tasks: 51 done, 5 ready
+- Total tasks: 52 done, 4 ready
 - Phase: 10 (Chat + Multi-Agent Dashboard)

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,11 +1,11 @@
 {
-  "last_updated": "2026-04-04T40:00Z",
+  "last_updated": "2026-04-04T42:00Z",
   "summary": {
-    "total_runs": 79,
-    "total_commits": 81,
-    "total_tests": 1192,
-    "tasks_completed": 51,
-    "tasks_remaining": 5,
+    "total_runs": 80,
+    "total_commits": 82,
+    "total_tests": 1205,
+    "tasks_completed": 52,
+    "tasks_remaining": 4,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
     "health": "GREEN"
   },
@@ -39,11 +39,11 @@
     },
     {
       "date": "2026-04-04",
-      "runs": 19,
-      "tasks_completed": 16,
-      "tests_passed": 1192,
+      "runs": 20,
+      "tasks_completed": 17,
+      "tests_passed": 1205,
       "tests_failed": 0,
-      "commits": 29,
+      "commits": 30,
       "health": "GREEN"
     }
   ],

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,8 +7,8 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 79,
-    "successful_runs": 74,
+    "total_runs": 80,
+    "successful_runs": 75,
     "failed_runs": 0,
     "success_rate": 1.0,
     "budget_remaining": 1.0,
@@ -98,6 +98,7 @@
     {"run_id": "2026-04-04-3600", "task": "#50 - Budget Analyst: real per-category cost breakdown in chat", "result": "success", "tests_passed": 1181, "tests_total": 1181},
     {"run_id": "2026-04-04-3800", "task": "#51 - Reporter agent: auto-close GitHub Issues on task completion", "result": "success", "tests_passed": 1181, "tests_total": 1181},
     {"run_id": "monitor-2026-04-04-3900", "task": "monitor", "result": "success", "tests_passed": 1181, "tests_total": 1181},
-    {"run_id": "2026-04-04-4000", "task": "#52 - Chat Secretary: export_calendar intent handler", "result": "success", "tests_passed": 1192, "tests_total": 1192}
+    {"run_id": "2026-04-04-4000", "task": "#52 - Chat Secretary: export_calendar intent handler", "result": "success", "tests_passed": 1192, "tests_total": 1192},
+    {"run_id": "2026-04-04-4200", "task": "#53 - Chat conversation context: pass last 10 messages to Gemini", "result": "success", "tests_passed": 1205, "tests_total": 1205}
   ]
 }

--- a/observability/logs/2026-04-04/run-42-00.json
+++ b/observability/logs/2026-04-04/run-42-00.json
@@ -1,0 +1,58 @@
+{
+  "trace": {
+    "run_id": "2026-04-04-4200",
+    "timestamp": "2026-04-04T42:00:00Z",
+    "phase": "Phase 10",
+    "health": "GREEN",
+    "task": "#53 - Chat conversation context: pass last 10 messages to Gemini",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "pass",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "selected_task": "#53 - Chat conversation context: pass last 10 messages to Gemini",
+      "github_issue": 34
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "reason": "backlog_ready_count >= 2, no architect needed"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "files_changed": ["src/app/chat.py", "src/app/schemas.py", "src/app/routers/chat.py", "tests/test_chat.py"],
+      "lines_added": 130,
+      "lines_removed": 18,
+      "notes": "Added message_history (list[dict]) to ChatSession for per-turn conversation context. ChatSession now stores up to _MAX_HISTORY_TURNS=10 turns (20 entries). extract_intent accepts optional history param and injects 'Previous conversation' section into Gemini prompt. process_message passes snapshot of session.message_history. ChatSessionOut schema and GET/POST session endpoints updated to expose message_history."
+    },
+    {
+      "agent": "qa",
+      "verdict": "pass",
+      "checks": {
+        "all_tests_pass": "pass",
+        "new_tests_exist": "pass",
+        "lint_clean": "pass",
+        "done_criteria_met": "pass",
+        "no_regressions": "pass",
+        "no_secrets_leaked": "pass"
+      },
+      "tests_passed": 1205,
+      "tests_total": 1205,
+      "new_tests": 13
+    }
+  ],
+  "ltes": {
+    "latency": {"total_duration_ms": 19980},
+    "traffic": {"commits": 1, "lines_added": 130, "lines_removed": 18, "files_changed": 4},
+    "errors": {"test_failures": 0, "fix_attempts": 0},
+    "saturation": {"backlog_remaining": 4}
+  }
+}

--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from app.ai import AIItineraryResult
 
 SESSION_TTL_SECONDS = 1800  # 30 minutes
+_MAX_HISTORY_TURNS = 10     # max conversation turns kept in message_history
 
 _DEFAULT_DEPARTURE = "Seoul"  # default origin for flight search
 
@@ -44,6 +45,7 @@ class ChatSession(BaseModel):
     created_at: datetime
     expires_at: datetime
     history: list[dict] = []
+    message_history: list[dict] = []   # last N turns for Gemini context (role/content pairs)
     agent_states: dict[str, dict] = {}  # last known agent_status per agent
     last_plan: Optional[dict] = None    # last plan_update payload
     last_saved_plan_id: Optional[int] = None  # DB plan_id after save_plan
@@ -101,26 +103,39 @@ class ChatService:
     # Intent extraction
     # ------------------------------------------------------------------
 
-    def extract_intent(self, message: str) -> Intent:
+    def extract_intent(self, message: str, history: Optional[list[dict]] = None) -> Intent:
         """Extract structured intent from user message via Gemini API.
 
         Falls back to action='general' if API key is missing or call fails.
+        Accepts optional ``history`` (list of {role, content} dicts) to provide
+        conversation context so follow-up messages can resolve references like
+        "3일차" or "그 목적지" from prior turns.
         """
         if not self._api_key:
             return Intent(action="general", raw_message=message)
 
         try:
-            prompt = f"""You are a travel planner AI assistant. Analyze the user message and extract their intent.
+            # Build conversation context section from the last N turns
+            context_section = ""
+            if history:
+                recent = history[-(_MAX_HISTORY_TURNS * 2):]
+                lines = [
+                    f"{entry.get('role', 'user').capitalize()}: {entry.get('content', '')}"
+                    for entry in recent
+                ]
+                context_section = "\n\nPrevious conversation:\n" + "\n".join(lines) + "\n"
 
+            prompt = f"""You are a travel planner AI assistant. Analyze the user message and extract their intent.
+{context_section}
 User message: "{message}"
 
 Return a JSON object with these fields:
 - action: one of "create_plan", "modify_day", "search_places", "search_hotels", "search_flights", "save_plan", "general"
-- destination: destination city/country if mentioned, else null
-- start_date: start date in YYYY-MM-DD if mentioned, else null
-- end_date: end date in YYYY-MM-DD if mentioned, else null
-- budget: budget as a number if mentioned, else null
-- interests: comma-separated interests if mentioned, else null
+- destination: destination city/country if mentioned or inferred from conversation context, else null
+- start_date: start date in YYYY-MM-DD if mentioned or inferred from context, else null
+- end_date: end date in YYYY-MM-DD if mentioned or inferred from context, else null
+- budget: budget as a number if mentioned or inferred from context, else null
+- interests: comma-separated interests if mentioned or inferred from context, else null
 - day_number: specific day number if modifying a day, else null
 - query: search query string if searching, else null
 - raw_message: the exact original message"""
@@ -170,7 +185,7 @@ Return a JSON object with these fields:
             "data": {"agent": "coordinator", "status": "thinking", "message": "요청 분석 중..."},
         })
 
-        intent = self.extract_intent(message)
+        intent = self.extract_intent(message, history=list(session.message_history))
 
         yield _track({
             "type": "agent_status",
@@ -187,33 +202,54 @@ Return a JSON object with these fields:
             "intent": intent.model_dump(),
         })
 
+        # Add user message to conversation history for future context
+        session.message_history.append({"role": "user", "content": message})
+
+        # Collect assistant response chunks to store in message_history
+        assistant_chunks: list[str] = []
+
+        def _track_and_collect(event: dict) -> dict:
+            """Track state and collect chat_chunk text for message_history."""
+            if event["type"] == "chat_chunk":
+                assistant_chunks.append(event["data"].get("text", ""))
+            return _track(event)
+
         # Dispatch to intent handlers, tracking state as events flow
         if intent.action == "create_plan":
             async for event in self._handle_create_plan(intent):
-                yield _track(event)
+                yield _track_and_collect(event)
         elif intent.action == "search_hotels":
             async for event in self._handle_search_hotels(intent):
-                yield _track(event)
+                yield _track_and_collect(event)
         elif intent.action == "search_flights":
             async for event in self._handle_search_flights(intent):
-                yield _track(event)
+                yield _track_and_collect(event)
         elif intent.action == "search_places":
             async for event in self._handle_search_places(intent):
-                yield _track(event)
+                yield _track_and_collect(event)
         elif intent.action == "modify_day":
             async for event in self._handle_modify_day(intent, session):
-                yield _track(event)
+                yield _track_and_collect(event)
         elif intent.action == "save_plan":
             async for event in self._handle_save_plan(intent, session, db):
-                yield _track(event)
+                yield _track_and_collect(event)
         elif intent.action == "export_calendar":
             async for event in self._handle_export_calendar(intent, session, db):
-                yield _track(event)
+                yield _track_and_collect(event)
         else:
+            _fallback_text = "어떤 여행을 계획하고 계신가요? 목적지, 날짜, 예산을 알려주세요."
+            assistant_chunks.append(_fallback_text)
             yield {
                 "type": "chat_chunk",
-                "data": {"text": "어떤 여행을 계획하고 계신가요? 목적지, 날짜, 예산을 알려주세요."},
+                "data": {"text": _fallback_text},
             }
+
+        # Append assistant response to message_history and cap at _MAX_HISTORY_TURNS
+        if assistant_chunks:
+            session.message_history.append({"role": "assistant", "content": " ".join(assistant_chunks)})
+        max_entries = _MAX_HISTORY_TURNS * 2
+        if len(session.message_history) > max_entries:
+            session.message_history = session.message_history[-max_entries:]
 
         yield {"type": "chat_done", "data": {}}
 

--- a/src/app/routers/chat.py
+++ b/src/app/routers/chat.py
@@ -24,6 +24,7 @@ def create_session():
         expires_at=session.expires_at,
         agent_states=session.agent_states,
         last_plan=session.last_plan,
+        message_history=session.message_history,
     )
 
 
@@ -39,6 +40,7 @@ def get_session(session_id: str):
         expires_at=session.expires_at,
         agent_states=session.agent_states,
         last_plan=session.last_plan,
+        message_history=session.message_history,
     )
 
 

--- a/src/app/schemas.py
+++ b/src/app/schemas.py
@@ -264,6 +264,7 @@ class ChatSessionOut(BaseModel):
     expires_at: datetime
     agent_states: dict = {}
     last_plan: Optional[dict] = None
+    message_history: list[dict] = []
 
 
 class AgentStatusEvent(BaseModel):

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-04T40:00Z (Evolve Run #75 — #52 Chat Secretary: export_calendar intent handler)
-Run count: 79
+Last run: 2026-04-04T42:00Z (Evolve Run #76 — #53 Chat conversation context: pass last 10 messages to Gemini)
+Run count: 80
 Phase: Phase 10: Chat + Multi-Agent Dashboard
 Health: GREEN
 Error Budget: HEALTHY
-Tasks completed: 51
+Tasks completed: 52
 Current focus: Phase 10 (Chat + Multi-Agent Dashboard)
-Next planned: #53 Chat conversation context: pass last 10 messages to Gemini
+Next planned: #56 Chat: list_plans intent handler
 
 ## LTES Snapshot
 
-- Latency: ~19950ms (pytest 1192 tests in 19.95s)
-- Traffic: 28 commits/24h
-- Errors: 0 test failures (1192/1192 pass), error_rate=0.0%
-- Saturation: 5 tasks ready
+- Latency: ~19980ms (pytest 1205 tests in 19.98s)
+- Traffic: 29 commits/24h
+- Errors: 0 test failures (1205/1205 pass), error_rate=0.0%
+- Saturation: 4 tasks ready
 
 ## Phase Transition
 
@@ -29,6 +29,15 @@ Next planned: #53 Chat conversation context: pass last 10 messages to Gemini
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #76 — 2026-04-04T42:00Z
+- **Task**: #53 - Chat conversation context: pass last 10 messages to Gemini
+- **Result**: GREEN ✓ (QA pass)
+- **Tests**: 1205/1205 passed (+13 new: TestConversationContext class, tests/test_chat.py:1441+)
+- **Files changed**: src/app/chat.py (+130/-18), src/app/schemas.py, src/app/routers/chat.py, tests/test_chat.py (+13 tests)
+- **Builder note**: Added message_history (list[dict]) to ChatSession for per-turn conversation context. _MAX_HISTORY_TURNS=10, cap enforced at 20 entries. extract_intent accepts optional history param and injects 'Previous conversation' section into Gemini prompt so follow-up messages resolve destination/dates/day_number from prior context. process_message passes snapshot of message_history; user/assistant turns appended after each exchange. ChatSessionOut schema and GET/POST session endpoints expose message_history.
+- **LTES**: L=19980ms T=1 commit E=0.0% S=4 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✓ → reporter ✓
 
 ### Evolve Run #75 — 2026-04-04T40:00Z
 - **Task**: #52 - Chat Secretary: export_calendar intent handler

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from app.ai import AIItineraryResult, AIDayItinerary, AIPlace
-from app.chat import ChatService, Intent, SESSION_TTL_SECONDS
+from app.chat import ChatService, Intent, SESSION_TTL_SECONDS, _MAX_HISTORY_TURNS
 from app.flight_search import FlightSearchResult, FlightResult
 from app.hotel_search import HotelSearchResult, HotelResult
 from app.web_search import DestinationSearchResult, PlaceSearchResult
@@ -1435,3 +1435,161 @@ class TestExportCalendar:
         finally:
             db.close()
             Base.metadata.drop_all(bind=engine)
+
+
+# ---------------------------------------------------------------------------
+# Task #53: Conversation context — message_history (max 10 turns) passed to Gemini
+# ---------------------------------------------------------------------------
+
+class TestConversationContext:
+    """ChatSession.message_history stores up to 10 turns; history is passed to
+    extract_intent so follow-up messages can infer prior context."""
+
+    def test_max_history_turns_constant_is_10(self):
+        """_MAX_HISTORY_TURNS must equal 10."""
+        assert _MAX_HISTORY_TURNS == 10
+
+    def test_session_has_message_history_field(self):
+        """ChatSession must have a message_history attribute initialized to []."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        assert hasattr(session, "message_history")
+        assert session.message_history == []
+
+    def test_user_message_appended_to_message_history(self):
+        """After process_message, message_history contains the user turn."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        _collect_events(svc, session.session_id, "도쿄 여행 계획해줘")
+        fetched = svc.get_session(session.session_id)
+        user_turns = [e for e in fetched.message_history if e["role"] == "user"]
+        assert len(user_turns) == 1
+        assert user_turns[0]["content"] == "도쿄 여행 계획해줘"
+
+    def test_assistant_response_appended_to_message_history(self):
+        """After process_message, message_history contains an assistant turn."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        _collect_events(svc, session.session_id, "안녕하세요")
+        fetched = svc.get_session(session.session_id)
+        assistant_turns = [e for e in fetched.message_history if e["role"] == "assistant"]
+        assert len(assistant_turns) == 1
+        assert assistant_turns[0]["content"]  # non-empty
+
+    def test_message_history_alternates_user_assistant(self):
+        """After two messages, message_history has user/assistant/user/assistant order."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        _collect_events(svc, session.session_id, "첫 번째 메시지")
+        _collect_events(svc, session.session_id, "두 번째 메시지")
+        fetched = svc.get_session(session.session_id)
+        roles = [e["role"] for e in fetched.message_history]
+        assert roles == ["user", "assistant", "user", "assistant"]
+
+    def test_message_history_capped_at_10_turns(self):
+        """Sending 12 messages must keep message_history at max 10 turns (20 entries)."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        for i in range(12):
+            _collect_events(svc, session.session_id, f"메시지 {i}")
+        fetched = svc.get_session(session.session_id)
+        max_entries = _MAX_HISTORY_TURNS * 2  # 10 turns = 10 user + 10 assistant
+        assert len(fetched.message_history) <= max_entries
+
+    def test_message_history_keeps_most_recent_turns(self):
+        """After exceeding max turns, the oldest turns are dropped."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        for i in range(12):
+            _collect_events(svc, session.session_id, f"메시지 {i}")
+        fetched = svc.get_session(session.session_id)
+        user_messages = [e["content"] for e in fetched.message_history if e["role"] == "user"]
+        # Most recent messages should be retained
+        assert "메시지 11" in user_messages
+        assert "메시지 10" in user_messages
+        # Oldest should be dropped
+        assert "메시지 0" not in user_messages
+
+    def test_extract_intent_receives_message_history(self):
+        """extract_intent must be called with the session's current message_history."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        # Pre-populate history to simulate a prior exchange
+        session.message_history = [
+            {"role": "user", "content": "도쿄 3박4일 여행 계획해줘"},
+            {"role": "assistant", "content": "도쿄 3박4일 여행 계획을 생성했습니다."},
+        ]
+
+        captured_kwargs = {}
+
+        original = svc.extract_intent
+
+        def spy_extract_intent(message, history=None):
+            captured_kwargs["history"] = history
+            return original(message, history=history)
+
+        svc.extract_intent = spy_extract_intent
+        _collect_events(svc, session.session_id, "3일차 맛집 위주로 바꿔줘")
+
+        assert "history" in captured_kwargs
+        assert captured_kwargs["history"] is not None
+        assert len(captured_kwargs["history"]) == 2
+
+    def test_extract_intent_with_history_includes_context_in_prompt(self):
+        """When history is passed, the Gemini prompt must include conversation context."""
+        history = [
+            {"role": "user", "content": "도쿄 3박4일 여행"},
+            {"role": "assistant", "content": "도쿄 3일 일정을 만들었습니다."},
+        ]
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = Intent(action="modify_day", day_number=2, raw_message="2일차 수정").model_dump_json()
+        mock_client.models.generate_content.return_value = mock_response
+
+        with patch("app.chat.genai") as mock_genai:
+            mock_genai.Client.return_value = mock_client
+            svc = ChatService(api_key="fake-key")
+            svc.extract_intent("2일차 자연 위주로 바꿔줘", history=history)
+
+        call_args = mock_client.models.generate_content.call_args
+        prompt_text = call_args[1]["contents"] if "contents" in call_args[1] else call_args[0][1]
+        # The prompt must reference the prior conversation
+        assert "도쿄 3박4일 여행" in prompt_text or "Previous" in prompt_text or "conversation" in prompt_text.lower()
+
+    def test_extract_intent_without_history_still_works(self):
+        """extract_intent with no history (default) must behave as before."""
+        svc = _make_service_no_api()
+        intent = svc.extract_intent("도쿄 여행 계획해줘")
+        assert isinstance(intent, Intent)
+        assert intent.action == "general"
+
+    def test_extract_intent_with_empty_history_still_works(self):
+        """extract_intent with empty history list behaves like no history."""
+        svc = _make_service_no_api()
+        intent = svc.extract_intent("도쿄 여행 계획해줘", history=[])
+        assert isinstance(intent, Intent)
+
+    def test_message_history_available_in_session_endpoint(self, client):
+        """GET /chat/sessions/{id} response includes message_history field."""
+        session_id = client.post("/chat/sessions").json()["session_id"]
+        client.post(
+            f"/chat/sessions/{session_id}/messages",
+            json={"message": "안녕하세요"},
+        )
+        resp = client.get(f"/chat/sessions/{session_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "message_history" in data
+
+    def test_message_history_entries_have_role_and_content(self, client):
+        """Each message_history entry must have 'role' and 'content' keys."""
+        session_id = client.post("/chat/sessions").json()["session_id"]
+        client.post(
+            f"/chat/sessions/{session_id}/messages",
+            json={"message": "안녕하세요"},
+        )
+        data = client.get(f"/chat/sessions/{session_id}").json()
+        for entry in data["message_history"]:
+            assert "role" in entry
+            assert "content" in entry
+            assert entry["role"] in ("user", "assistant")


### PR DESCRIPTION
## Evolve Run #76
- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: GREEN
- **Task**: #53 - Chat conversation context: pass last 10 messages to Gemini
- **QA**: pass
- **Tests**: 1205/1205 (13 new)

Closes #34

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #53, health GREEN, 1192/1192 tests |
| 📐 Architect | ⏭️ | Skipped (backlog_ready_count >= 2) |
| 🔨 Builder | ✅ | src/app/chat.py, src/app/schemas.py, src/app/routers/chat.py, tests/test_chat.py (+130/-18) |
| 🧪 QA | ✅ | 1205/1205 pass, 13 new tests, lint clean, done criteria met |
| 📝 Reporter | ✅ | This PR |

### Changes
- Added `message_history` (list[dict]) to `ChatSession` for per-turn conversation context
- `_MAX_HISTORY_TURNS=10`, capped at 20 entries (10 user + 10 assistant)
- `extract_intent` accepts optional `history` param; injects "Previous conversation" section into Gemini prompt
- `process_message` passes snapshot of `session.message_history` at call time; appends user/assistant turns after each exchange
- `ChatSessionOut` schema and GET/POST session endpoints now expose `message_history`

🤖 Auto-generated by Evolve Pipeline