### PR TITLE
feat: Chat delete_plan intent handler — delete a saved plan via chat (#59)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -12,12 +12,6 @@ _(없음)_
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
 
-- [ ] #59 - Chat: `delete_plan` intent handler — delete a saved plan via chat [feature]
-  - ref: markdowns/feat-chat-dashboard.md
-  - files: src/app/chat.py, src/app/static/chat.js, tests/test_chat.py
-  - done: `delete_plan` intent routes to handler; deletes from DB; emits `plan_deleted`; frontend clears plan-panel; ≥3 tests added
-  - gh: #45
-
 - [ ] #60 - Chat: `view_plan` intent handler — load saved plan into dashboard by name/ID [feature]
   - ref: markdowns/feat-chat-dashboard.md
   - files: src/app/chat.py, tests/test_chat.py
@@ -107,6 +101,7 @@ _(없음)_
 - [x] #55 - Incident auto-issue: create Bug GitHub Issue on 3 consecutive QA failures [infra] — 2026-04-04
 - [x] #57 - Chat frontend: plans_list SSE event handler — render saved plan cards in dashboard [feature] — 2026-04-04
 - [x] #58 - Chat frontend: `calendar_exported` SSE event handler — show export confirmation [feature] — 2026-04-04
+- [x] #59 - Chat: `delete_plan` intent handler — delete a saved plan via chat [feature] — 2026-04-04
 
 ### Phase 9: User Experience & Polish (remaining, completed)
 - [x] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature] — 2026-04-04
@@ -118,5 +113,5 @@ _(없음)_
 ## Metrics
 
 - Velocity: 1 task/run
-- Total tasks: 57 done, 4 ready
+- Total tasks: 58 done, 3 ready
 - Phase: 10 (Chat + Multi-Agent Dashboard)

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,11 +1,11 @@
 {
-  "last_updated": "2026-04-04T51:00Z",
+  "last_updated": "2026-04-04T54:00Z",
   "summary": {
-    "total_runs": 87,
-    "total_commits": 87,
-    "total_tests": 1232,
-    "tasks_completed": 56,
-    "tasks_remaining": 5,
+    "total_runs": 89,
+    "total_commits": 89,
+    "total_tests": 1241,
+    "tasks_completed": 58,
+    "tasks_remaining": 3,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
     "health": "GREEN"
   },
@@ -39,11 +39,11 @@
     },
     {
       "date": "2026-04-04",
-      "runs": 26,
-      "tasks_completed": 21,
-      "tests_passed": 1232,
+      "runs": 28,
+      "tasks_completed": 23,
+      "tests_passed": 1241,
       "tests_failed": 0,
-      "commits": 34,
+      "commits": 36,
       "health": "GREEN"
     }
   ],
@@ -60,10 +60,10 @@
     "health": "GREEN"
   },
   "last_evolve": {
-    "timestamp": "2026-04-04T50:00Z",
-    "run_id": "2026-04-04-5000",
-    "task": "#57 - Chat frontend: plans_list SSE event handler",
-    "tests_passed": 1232,
+    "timestamp": "2026-04-04T54:00Z",
+    "run_id": "2026-04-04-5400",
+    "task": "#59 - Chat: delete_plan intent handler — delete a saved plan via chat",
+    "tests_passed": 1241,
     "tests_failed": 0,
     "health": "GREEN"
   }

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,8 +7,8 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 88,
-    "successful_runs": 83,
+    "total_runs": 89,
+    "successful_runs": 84,
     "failed_runs": 0,
     "success_rate": 1.0,
     "budget_remaining": 1.0,
@@ -635,14 +635,21 @@
       "result": "success",
       "tests_passed": 1235,
       "tests_total": 1235
+    },
+    {
+      "run_id": "2026-04-04-5400",
+      "task": "#59 - Chat: delete_plan intent handler — delete a saved plan via chat",
+      "result": "success",
+      "tests_passed": 1241,
+      "tests_total": 1241
     }
   ],
   "consecutive_qa_failures": 0,
   "history_tail": {
-    "run_id": "2026-04-04-5200",
-    "task": "#58 - Chat frontend: calendar_exported SSE event handler — show export confirmation",
+    "run_id": "2026-04-04-5400",
+    "task": "#59 - Chat: delete_plan intent handler — delete a saved plan via chat",
     "result": "success",
-    "tests_passed": 1235,
-    "tests_total": 1235
+    "tests_passed": 1241,
+    "tests_total": 1241
   }
 }

--- a/observability/logs/2026-04-04/run-54-00.json
+++ b/observability/logs/2026-04-04/run-54-00.json
@@ -1,0 +1,61 @@
+{
+  "trace": {
+    "run_id": "2026-04-04-5400",
+    "timestamp": "2026-04-04T00:00:00Z",
+    "phase": "Phase 10",
+    "health": "GREEN",
+    "task": "#59 - Chat: delete_plan intent handler — delete a saved plan via chat",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "pass",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #59 (delete_plan intent handler). Health GREEN, 1235/1235 tests passing."
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "Backlog has 3 ready tasks (>2), architect not needed."
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "Added delete_plan intent handler: Intent model gains plan_id field; extract_intent prompt updated; _handle_delete_plan resolves plan_id, deletes TravelPlan from DB, emits plan_deleted SSE event; chat.js handles plan_deleted by clearing plan-panel; 6 new tests added. 1241/1241 tests pass."
+    },
+    {
+      "agent": "qa",
+      "status": "pass",
+      "detail": "1241/1241 passed in 19.79s. All checks: all_tests_pass, new_tests_exist, lint_clean, done_criteria_met, no_regressions, no_secrets_leaked."
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Writing logs, updating status, creating PR."
+    }
+  ],
+  "ltes": {
+    "latency": {
+      "total_duration_ms": 19790
+    },
+    "traffic": {
+      "commits": 1,
+      "lines_added": 85,
+      "lines_removed": 2,
+      "files_changed": 3
+    },
+    "errors": {
+      "test_failures": 0,
+      "fix_attempts": 0
+    },
+    "saturation": {
+      "backlog_remaining": 3
+    }
+  }
+}

--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -28,13 +28,14 @@ _DEFAULT_DEPARTURE = "Seoul"  # default origin for flight search
 
 
 class Intent(BaseModel):
-    action: str  # create_plan | modify_day | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | general
+    action: str  # create_plan | modify_day | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | delete_plan | general
     destination: Optional[str] = None
     start_date: Optional[str] = None
     end_date: Optional[str] = None
     budget: Optional[float] = None
     interests: Optional[str] = None
     day_number: Optional[int] = None
+    plan_id: Optional[int] = None
     query: Optional[str] = None
     access_token: Optional[str] = None
     raw_message: str = ""
@@ -130,13 +131,14 @@ class ChatService:
 User message: "{message}"
 
 Return a JSON object with these fields:
-- action: one of "create_plan", "modify_day", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "general"
+- action: one of "create_plan", "modify_day", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "general"
 - destination: destination city/country if mentioned or inferred from conversation context, else null
 - start_date: start date in YYYY-MM-DD if mentioned or inferred from context, else null
 - end_date: end date in YYYY-MM-DD if mentioned or inferred from context, else null
 - budget: budget as a number if mentioned or inferred from context, else null
 - interests: comma-separated interests if mentioned or inferred from context, else null
 - day_number: specific day number if modifying a day, else null
+- plan_id: integer plan ID if deleting a specific plan (e.g. "3번 계획 삭제" → 3), else null
 - query: search query string if searching, else null
 - raw_message: the exact original message"""
 
@@ -238,6 +240,9 @@ Return a JSON object with these fields:
                 yield _track_and_collect(event)
         elif intent.action == "list_plans":
             async for event in self._handle_list_plans(db):
+                yield _track_and_collect(event)
+        elif intent.action == "delete_plan":
+            async for event in self._handle_delete_plan(intent, session, db):
                 yield _track_and_collect(event)
         else:
             _fallback_text = "어떤 여행을 계획하고 계신가요? 목적지, 날짜, 예산을 알려주세요."
@@ -834,6 +839,79 @@ Return a JSON object with these fields:
             yield {
                 "type": "chat_chunk",
                 "data": {"text": f"여행 계획 조회 중 오류가 발생했습니다: {exc}"},
+            }
+
+
+    async def _handle_delete_plan(
+        self,
+        intent: Intent,
+        session: "ChatSession",
+        db: Optional["Session"] = None,
+    ) -> AsyncGenerator[dict, None]:
+        yield {
+            "type": "agent_status",
+            "data": {"agent": "secretary", "status": "working", "message": "여행 계획 삭제 중..."},
+        }
+        await asyncio.sleep(0)
+
+        # Resolve the plan ID: prefer explicit intent.plan_id, then session's last saved plan
+        plan_id: Optional[int] = intent.plan_id or session.last_saved_plan_id
+
+        if db is None or plan_id is None:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "secretary", "status": "error", "message": "삭제할 계획을 찾을 수 없습니다"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": "삭제할 여행 계획을 지정해주세요. (예: '3번 계획 삭제')"},
+            }
+            return
+
+        try:
+            from app.models import TravelPlan as TravelPlanModel
+
+            plan = db.get(TravelPlanModel, plan_id)
+            if plan is None:
+                yield {
+                    "type": "agent_status",
+                    "data": {"agent": "secretary", "status": "error", "message": f"계획 #{plan_id}을 찾을 수 없습니다"},
+                }
+                yield {
+                    "type": "chat_chunk",
+                    "data": {"text": f"계획 #{plan_id}을 찾을 수 없습니다."},
+                }
+                return
+
+            destination = plan.destination
+            db.delete(plan)
+            db.commit()
+
+            # Clear the session's saved plan reference if it matches
+            if session.last_saved_plan_id == plan_id:
+                session.last_saved_plan_id = None
+
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "secretary", "status": "done", "message": "삭제 완료!"},
+            }
+            yield {
+                "type": "plan_deleted",
+                "data": {"plan_id": plan_id, "destination": destination},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"'{destination}' 여행 계획(#{plan_id})이 삭제되었습니다."},
+            }
+
+        except Exception as exc:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "secretary", "status": "error", "message": "삭제 실패"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"여행 계획 삭제 중 오류가 발생했습니다: {exc}"},
             }
 
 

--- a/src/app/static/chat.js
+++ b/src/app/static/chat.js
@@ -240,6 +240,13 @@ function handleSseEvent(event) {
     case 'plan_saved':
       appendAiBubble('✅ ' + ((event.data && event.data.message) || '저장 완료'));
       break;
+    case 'plan_deleted': {
+      const panel = document.getElementById('plan-panel');
+      if (panel) {
+        panel.innerHTML = '<div class="meta">여행 계획이 삭제되었습니다.</div>';
+      }
+      break;
+    }
     case 'error':
       const errMsg = (event.data && event.data.message) || '오류 발생';
       if (currentStreamBubble) {

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-04T52:00Z (Evolve Run #81)
-Run count: 88
+Last run: 2026-04-04T54:00Z (Evolve Run #82)
+Run count: 89
 Phase: Phase 10: Chat + Multi-Agent Dashboard
 Health: GREEN
 Error Budget: HEALTHY
-Tasks completed: 57
+Tasks completed: 58
 Current focus: Phase 10 (Chat + Multi-Agent Dashboard)
-Next planned: #59 Chat: delete_plan intent handler
+Next planned: #60 Chat: view_plan intent handler
 
 ## LTES Snapshot
 
-- Latency: ~0ms (pytest 1235 tests)
+- Latency: ~19790ms (pytest 1241 tests)
 - Traffic: 35 commits/24h
-- Errors: 0 test failures (1235/1235 pass), error_rate=0.0%
-- Saturation: 4 tasks ready
+- Errors: 0 test failures (1241/1241 pass), error_rate=0.0%
+- Saturation: 3 tasks ready
 
 ## Phase Transition
 
@@ -29,6 +29,15 @@ Next planned: #59 Chat: delete_plan intent handler
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #82 — 2026-04-04T54:00Z
+- **Task**: #59 - Chat: `delete_plan` intent handler — delete a saved plan via chat
+- **Result**: GREEN ✓ (QA pass)
+- **Tests**: 1241/1241 passed (+6 new: TestDeletePlanIntent class, tests/test_chat.py:1863+)
+- **Files changed**: src/app/chat.py (+85/-2), src/app/static/chat.js, tests/test_chat.py (+6 tests)
+- **Builder note**: Added delete_plan intent handler: Intent model gains plan_id field; extract_intent prompt updated to include delete_plan action; _handle_delete_plan resolves plan_id from intent.plan_id or session.last_saved_plan_id, deletes TravelPlan from DB, emits plan_deleted SSE event, clears session.last_saved_plan_id if it matches; chat.js handles plan_deleted by clearing plan-panel. 6 new tests: secretary activation, plan_deleted event emission, DB deletion, no-DB error path, nonexistent plan error, session state cleanup.
+- **LTES**: L=19790ms T=1 commit E=0.0% S=3 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✓ → reporter ✓
 
 ### Evolve Run #81 — 2026-04-04T52:00Z
 - **Task**: #58 - Chat frontend: `calendar_exported` SSE event handler — show export confirmation

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1857,3 +1857,168 @@ class TestConversationContext:
             assert "role" in entry
             assert "content" in entry
             assert entry["role"] in ("user", "assistant")
+
+
+# ---------------------------------------------------------------------------
+# Task #59: delete_plan intent handler
+# ---------------------------------------------------------------------------
+
+class TestDeletePlan:
+    """_handle_delete_plan must delete the plan from DB and emit plan_deleted."""
+
+    def test_delete_plan_activates_secretary(self):
+        """delete_plan intent activates the secretary agent."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="delete_plan", plan_id=1, raw_message="계획 삭제"
+        )):
+            events = _collect_events(svc, session.session_id, "계획 삭제")
+
+        agent_names = {e["data"]["agent"] for e in events if e["type"] == "agent_status"}
+        assert "secretary" in agent_names
+
+    def test_delete_plan_emits_plan_deleted_event(self):
+        """delete_plan must emit a plan_deleted SSE event when DB record is found."""
+        from app.database import Base
+        from app.models import TravelPlan as TravelPlanModel
+        from datetime import date
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            # Insert a plan to delete
+            plan = TravelPlanModel(
+                destination="바르셀로나",
+                start_date=date(2026, 7, 1),
+                end_date=date(2026, 7, 5),
+                budget=1800000.0,
+            )
+            db.add(plan)
+            db.commit()
+            db.refresh(plan)
+            plan_id = plan.id
+
+            svc = _make_service_no_api()
+            session = svc.create_session()
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="delete_plan", plan_id=plan_id, raw_message="계획 삭제"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "계획 삭제", db)
+
+            deleted_events = [e for e in events if e["type"] == "plan_deleted"]
+            assert len(deleted_events) == 1
+            assert deleted_events[0]["data"]["plan_id"] == plan_id
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)
+
+    def test_delete_plan_removes_from_db(self):
+        """delete_plan must physically remove the TravelPlan row from the database."""
+        from app.database import Base
+        from app.models import TravelPlan as TravelPlanModel
+        from datetime import date
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan = TravelPlanModel(
+                destination="런던",
+                start_date=date(2026, 8, 1),
+                end_date=date(2026, 8, 7),
+                budget=3000000.0,
+            )
+            db.add(plan)
+            db.commit()
+            db.refresh(plan)
+            plan_id = plan.id
+
+            svc = _make_service_no_api()
+            session = svc.create_session()
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="delete_plan", plan_id=plan_id, raw_message="삭제"
+            )):
+                _collect_events_with_db(svc, session.session_id, "삭제", db)
+
+            remaining = db.query(TravelPlanModel).filter(TravelPlanModel.id == plan_id).first()
+            assert remaining is None
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)
+
+    def test_delete_plan_no_db_emits_error(self):
+        """delete_plan without a DB session must emit an error agent_status."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="delete_plan", plan_id=99, raw_message="삭제"
+        )):
+            events = _collect_events(svc, session.session_id, "삭제")
+
+        error_events = [
+            e for e in events
+            if e["type"] == "agent_status" and e["data"]["status"] == "error"
+        ]
+        assert len(error_events) >= 1
+
+    def test_delete_plan_nonexistent_plan_emits_error(self):
+        """delete_plan for a missing plan_id must emit an error agent_status."""
+        from app.database import Base
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            svc = _make_service_no_api()
+            session = svc.create_session()
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="delete_plan", plan_id=9999, raw_message="삭제"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "삭제", db)
+
+            error_events = [
+                e for e in events
+                if e["type"] == "agent_status" and e["data"]["status"] == "error"
+            ]
+            assert len(error_events) >= 1
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)
+
+    def test_delete_plan_clears_session_last_saved_plan_id(self):
+        """After deleting the last saved plan, session.last_saved_plan_id must be cleared."""
+        from app.database import Base
+        from app.models import TravelPlan as TravelPlanModel
+        from datetime import date
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan = TravelPlanModel(
+                destination="뉴욕",
+                start_date=date(2026, 9, 1),
+                end_date=date(2026, 9, 5),
+                budget=5000000.0,
+            )
+            db.add(plan)
+            db.commit()
+            db.refresh(plan)
+            plan_id = plan.id
+
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_saved_plan_id = plan_id
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="delete_plan", plan_id=plan_id, raw_message="삭제"
+            )):
+                _collect_events_with_db(svc, session.session_id, "삭제", db)
+
+            assert session.last_saved_plan_id is None
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)


### PR DESCRIPTION
## Evolve Run #82
- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: GREEN
- **Task**: #59 - Chat: `delete_plan` intent handler — delete a saved plan via chat
- **QA**: pass
- **Tests**: 1241/1241

Closes #45

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #59. Health GREEN, 1235/1235 tests passing. |
| 📐 Architect | ⏭️ | Skipped — 3 ready tasks in backlog (>2 threshold). |
| 🔨 Builder | ✅ | Added `delete_plan` intent handler: Intent.plan_id field; extract_intent prompt updated; `_handle_delete_plan` deletes TravelPlan from DB, emits `plan_deleted` SSE; chat.js clears plan-panel on `plan_deleted`; 6 new tests (+85/-2 lines, 3 files). |
| 🧪 QA | ✅ | 1241/1241 passed in 19.79s — all checks pass (tests, lint, done_criteria, no_regressions, no_secrets_leaked). |
| 📝 Reporter | ✅ | This PR |

🤖 Auto-generated by Evolve Pipeline