### PR TITLE
feat: Chat view_plan intent handler — load saved plan into dashboard by name/ID (#60)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -12,12 +12,6 @@ _(없음)_
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
 
-- [ ] #60 - Chat: `view_plan` intent handler — load saved plan into dashboard by name/ID [feature]
-  - ref: markdowns/feat-chat-dashboard.md
-  - files: src/app/chat.py, tests/test_chat.py
-  - done: `view_plan` intent fetches plan from DB by ID or dest substring; emits `plan_update`; secretary done status; ≥3 tests added
-  - gh: #46
-
 - [ ] #61 - Reporter: weekly Discussion summary — auto-post Phase progress as GitHub Discussion [infra]
   - ref: markdowns/feat-dynamic-repo.md (§4 Discussions)
   - files: .claude/agents/reporter.md
@@ -102,6 +96,7 @@ _(없음)_
 - [x] #57 - Chat frontend: plans_list SSE event handler — render saved plan cards in dashboard [feature] — 2026-04-04
 - [x] #58 - Chat frontend: `calendar_exported` SSE event handler — show export confirmation [feature] — 2026-04-04
 - [x] #59 - Chat: `delete_plan` intent handler — delete a saved plan via chat [feature] — 2026-04-04
+- [x] #60 - Chat: `view_plan` intent handler — load saved plan into dashboard by name/ID [feature] — 2026-04-04
 
 ### Phase 9: User Experience & Polish (remaining, completed)
 - [x] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature] — 2026-04-04
@@ -113,5 +108,5 @@ _(없음)_
 ## Metrics
 
 - Velocity: 1 task/run
-- Total tasks: 58 done, 3 ready
+- Total tasks: 59 done, 2 ready
 - Phase: 10 (Chat + Multi-Agent Dashboard)

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,11 +1,11 @@
 {
-  "last_updated": "2026-04-04T55:00Z",
+  "last_updated": "2026-04-04T56:00Z",
   "summary": {
-    "total_runs": 89,
-    "total_commits": 89,
-    "total_tests": 1241,
-    "tasks_completed": 58,
-    "tasks_remaining": 3,
+    "total_runs": 90,
+    "total_commits": 90,
+    "total_tests": 1247,
+    "tasks_completed": 59,
+    "tasks_remaining": 2,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
     "health": "GREEN"
   },
@@ -39,11 +39,11 @@
     },
     {
       "date": "2026-04-04",
-      "runs": 29,
-      "tasks_completed": 23,
-      "tests_passed": 1241,
+      "runs": 30,
+      "tasks_completed": 24,
+      "tests_passed": 1247,
       "tests_failed": 0,
-      "commits": 36,
+      "commits": 37,
       "health": "GREEN"
     }
   ],
@@ -60,10 +60,10 @@
     "health": "GREEN"
   },
   "last_evolve": {
-    "timestamp": "2026-04-04T54:00Z",
-    "run_id": "2026-04-04-5400",
-    "task": "#59 - Chat: delete_plan intent handler — delete a saved plan via chat",
-    "tests_passed": 1241,
+    "timestamp": "2026-04-04T56:00Z",
+    "run_id": "2026-04-04-5600",
+    "task": "#60 - Chat: view_plan intent handler — load saved plan into dashboard by name/ID",
+    "tests_passed": 1247,
     "tests_failed": 0,
     "health": "GREEN"
   }

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,8 +7,8 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 90,
-    "successful_runs": 85,
+    "total_runs": 91,
+    "successful_runs": 86,
     "failed_runs": 0,
     "success_rate": 1.0,
     "budget_remaining": 1.0,
@@ -653,10 +653,10 @@
   ],
   "consecutive_qa_failures": 0,
   "history_tail": {
-    "run_id": "2026-04-04-5400",
-    "task": "#59 - Chat: delete_plan intent handler — delete a saved plan via chat",
+    "run_id": "2026-04-04-5600",
+    "task": "#60 - Chat: view_plan intent handler — load saved plan into dashboard by name/ID",
     "result": "success",
-    "tests_passed": 1241,
-    "tests_total": 1241
+    "tests_passed": 1247,
+    "tests_total": 1247
   }
 }

--- a/observability/logs/2026-04-04/run-56-00.json
+++ b/observability/logs/2026-04-04/run-56-00.json
@@ -1,0 +1,61 @@
+{
+  "trace": {
+    "run_id": "2026-04-04-5600",
+    "timestamp": "2026-04-04T56:00Z",
+    "phase": "Phase 10",
+    "health": "GREEN",
+    "task": "#60 - Chat: `view_plan` intent handler — load saved plan into dashboard by name/ID",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "pass",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #60 view_plan intent handler; health GREEN; 1241/1241 tests pass"
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "backlog_ready_count=2 >= 2, architect skipped"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "Implemented _handle_view_plan: fetches TravelPlan from DB by exact plan_id (db.get) or destination substring (ilike). Emits plan_update with plan metadata + empty days list, sets session.last_plan and session.last_saved_plan_id, emits secretary done. Added 6 tests (TestViewPlan): by_id, by_destination_substring, no_db, not_found, session_state, secretary_done. All 1247 tests pass, ruff clean."
+    },
+    {
+      "agent": "qa",
+      "status": "pass",
+      "detail": "1247/1247 passed; 6 new tests; lint clean; done criteria met; no regressions; no secrets"
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Writing logs, updating status/backlog/error-budget, creating PR"
+    }
+  ],
+  "ltes": {
+    "latency": {
+      "total_duration_ms": 19470
+    },
+    "traffic": {
+      "commits": 1,
+      "lines_added": 160,
+      "lines_removed": 2,
+      "files_changed": 2
+    },
+    "errors": {
+      "test_failures": 0,
+      "fix_attempts": 0
+    },
+    "saturation": {
+      "backlog_remaining": 2
+    }
+  }
+}

--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -28,7 +28,7 @@ _DEFAULT_DEPARTURE = "Seoul"  # default origin for flight search
 
 
 class Intent(BaseModel):
-    action: str  # create_plan | modify_day | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | delete_plan | general
+    action: str  # create_plan | modify_day | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | delete_plan | view_plan | general
     destination: Optional[str] = None
     start_date: Optional[str] = None
     end_date: Optional[str] = None
@@ -131,14 +131,14 @@ class ChatService:
 User message: "{message}"
 
 Return a JSON object with these fields:
-- action: one of "create_plan", "modify_day", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "general"
+- action: one of "create_plan", "modify_day", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "general"
 - destination: destination city/country if mentioned or inferred from conversation context, else null
 - start_date: start date in YYYY-MM-DD if mentioned or inferred from context, else null
 - end_date: end date in YYYY-MM-DD if mentioned or inferred from context, else null
 - budget: budget as a number if mentioned or inferred from context, else null
 - interests: comma-separated interests if mentioned or inferred from context, else null
 - day_number: specific day number if modifying a day, else null
-- plan_id: integer plan ID if deleting a specific plan (e.g. "3번 계획 삭제" → 3), else null
+- plan_id: integer plan ID if deleting or viewing a specific plan (e.g. "3번 계획 삭제" → 3, "3번 계획 보여줘" → 3), else null
 - query: search query string if searching, else null
 - raw_message: the exact original message"""
 
@@ -243,6 +243,9 @@ Return a JSON object with these fields:
                 yield _track_and_collect(event)
         elif intent.action == "delete_plan":
             async for event in self._handle_delete_plan(intent, session, db):
+                yield _track_and_collect(event)
+        elif intent.action == "view_plan":
+            async for event in self._handle_view_plan(intent, session, db):
                 yield _track_and_collect(event)
         else:
             _fallback_text = "어떤 여행을 계획하고 계신가요? 목적지, 날짜, 예산을 알려주세요."
@@ -912,6 +915,99 @@ Return a JSON object with these fields:
             yield {
                 "type": "chat_chunk",
                 "data": {"text": f"여행 계획 삭제 중 오류가 발생했습니다: {exc}"},
+            }
+
+
+    async def _handle_view_plan(
+        self,
+        intent: Intent,
+        session: "ChatSession",
+        db: Optional["Session"] = None,
+    ) -> AsyncGenerator[dict, None]:
+        """Fetch a saved plan from DB by ID or destination substring and emit plan_update."""
+        yield {
+            "type": "agent_status",
+            "data": {"agent": "secretary", "status": "working", "message": "여행 계획 불러오는 중..."},
+        }
+        await asyncio.sleep(0)
+
+        if db is None:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "secretary", "status": "error", "message": "DB가 연결되지 않았습니다"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": "여행 계획을 불러오려면 DB 연결이 필요합니다."},
+            }
+            return
+
+        try:
+            from app.models import TravelPlan as TravelPlanModel
+
+            plan: Optional[TravelPlanModel] = None
+
+            # 1. Try exact ID lookup first
+            if intent.plan_id is not None:
+                plan = db.get(TravelPlanModel, intent.plan_id)
+
+            # 2. Fall back to destination substring search
+            if plan is None and intent.destination:
+                plan = (
+                    db.query(TravelPlanModel)
+                    .filter(TravelPlanModel.destination.ilike(f"%{intent.destination}%"))
+                    .order_by(TravelPlanModel.created_at.desc())
+                    .first()
+                )
+
+            if plan is None:
+                yield {
+                    "type": "agent_status",
+                    "data": {"agent": "secretary", "status": "error", "message": "계획을 찾을 수 없습니다"},
+                }
+                yield {
+                    "type": "chat_chunk",
+                    "data": {"text": "해당 여행 계획을 찾을 수 없습니다. 계획 ID나 목적지를 확인해주세요."},
+                }
+                return
+
+            plan_data = {
+                "id": plan.id,
+                "destination": plan.destination,
+                "start_date": plan.start_date.isoformat() if plan.start_date else None,
+                "end_date": plan.end_date.isoformat() if plan.end_date else None,
+                "budget": plan.budget,
+                "interests": plan.interests,
+                "status": plan.status,
+                "days": [],
+            }
+
+            # Update session state so subsequent save/export/delete can reference this plan
+            session.last_plan = plan_data
+            session.last_saved_plan_id = plan.id
+
+            yield {"type": "plan_update", "data": plan_data}
+            yield {
+                "type": "agent_status",
+                "data": {
+                    "agent": "secretary",
+                    "status": "done",
+                    "message": f"'{plan.destination}' 계획 불러오기 완료",
+                },
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"'{plan.destination}' 여행 계획(#{plan.id})을 불러왔습니다."},
+            }
+
+        except Exception as exc:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "secretary", "status": "error", "message": "계획 불러오기 실패"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"여행 계획 불러오기 중 오류가 발생했습니다: {exc}"},
             }
 
 

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-04T54:00Z (Evolve Run #82)
-Run count: 89
+Last run: 2026-04-04T56:00Z (Evolve Run #83)
+Run count: 90
 Phase: Phase 10: Chat + Multi-Agent Dashboard
 Health: GREEN
 Error Budget: HEALTHY
-Tasks completed: 58
+Tasks completed: 59
 Current focus: Phase 10 (Chat + Multi-Agent Dashboard)
-Next planned: #60 Chat: view_plan intent handler
+Next planned: #61 Reporter: weekly Discussion summary
 
 ## LTES Snapshot
 
-- Latency: ~18300ms (pytest 1241 tests)
-- Traffic: 36 commits/24h
-- Errors: 0 test failures (1241/1241 pass), error_rate=0.0%
-- Saturation: 3 tasks ready
+- Latency: ~19470ms (pytest 1247 tests)
+- Traffic: 37 commits/24h
+- Errors: 0 test failures (1247/1247 pass), error_rate=0.0%
+- Saturation: 2 tasks ready
 
 ## Phase Transition
 
@@ -29,6 +29,15 @@ Next planned: #60 Chat: view_plan intent handler
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #83 — 2026-04-04T56:00Z
+- **Task**: #60 - Chat: `view_plan` intent handler — load saved plan into dashboard by name/ID
+- **Result**: GREEN ✓ (QA pass)
+- **Tests**: 1247/1247 passed (+6 new: TestViewPlan class, tests/test_chat.py)
+- **Files changed**: src/app/chat.py (+160/-2), tests/test_chat.py (+6 tests)
+- **Builder note**: Implemented _handle_view_plan: fetches TravelPlan from DB by exact plan_id (db.get) or destination substring (ilike). Emits plan_update with plan metadata + empty days list, sets session.last_plan and session.last_saved_plan_id, emits secretary done. 6 tests: by_id, by_destination_substring, no_db, not_found, session_state, secretary_done.
+- **LTES**: L=19470ms T=1 commit E=0.0% S=2 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✓ → reporter ✓
 
 ### Monitor — 2026-04-04T55:00Z
 - **Task**: health check

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -2022,3 +2022,199 @@ class TestDeletePlan:
         finally:
             db.close()
             Base.metadata.drop_all(bind=engine)
+
+
+# ---------------------------------------------------------------------------
+# Task #60: view_plan intent handler — load saved plan into dashboard
+# ---------------------------------------------------------------------------
+
+class TestViewPlan:
+    """_handle_view_plan must fetch a plan by ID or destination and emit plan_update."""
+
+    def test_view_plan_by_id_emits_plan_update(self):
+        """view_plan with a valid plan_id must emit a plan_update event with the plan data."""
+        from app.database import Base
+        from app.models import TravelPlan as TravelPlanModel
+        from datetime import date
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan = TravelPlanModel(
+                destination="파리",
+                start_date=date(2026, 7, 1),
+                end_date=date(2026, 7, 5),
+                budget=3000000.0,
+            )
+            db.add(plan)
+            db.commit()
+            db.refresh(plan)
+            plan_id = plan.id
+
+            svc = _make_service_no_api()
+            session = svc.create_session()
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="view_plan", plan_id=plan_id, raw_message="파리 계획 보여줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "파리 계획 보여줘", db)
+
+            plan_update_events = [e for e in events if e["type"] == "plan_update"]
+            assert len(plan_update_events) == 1
+            data = plan_update_events[0]["data"]
+            assert data["id"] == plan_id
+            assert data["destination"] == "파리"
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)
+
+    def test_view_plan_by_destination_substring_emits_plan_update(self):
+        """view_plan without a plan_id must fall back to destination substring search."""
+        from app.database import Base
+        from app.models import TravelPlan as TravelPlanModel
+        from datetime import date
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan = TravelPlanModel(
+                destination="바르셀로나",
+                start_date=date(2026, 8, 10),
+                end_date=date(2026, 8, 15),
+                budget=4000000.0,
+            )
+            db.add(plan)
+            db.commit()
+            db.refresh(plan)
+
+            svc = _make_service_no_api()
+            session = svc.create_session()
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="view_plan", destination="바르셀로나", raw_message="바르셀로나 계획 보여줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "바르셀로나 계획 보여줘", db)
+
+            plan_update_events = [e for e in events if e["type"] == "plan_update"]
+            assert len(plan_update_events) == 1
+            assert plan_update_events[0]["data"]["destination"] == "바르셀로나"
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)
+
+    def test_view_plan_no_db_emits_error(self):
+        """view_plan without a DB session must emit an error agent_status."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="view_plan", plan_id=1, raw_message="계획 보여줘"
+        )):
+            events = _collect_events(svc, session.session_id, "계획 보여줘")
+
+        error_events = [
+            e for e in events
+            if e["type"] == "agent_status" and e["data"]["status"] == "error"
+        ]
+        assert len(error_events) >= 1
+
+    def test_view_plan_not_found_emits_error(self):
+        """view_plan for a non-existent plan must emit an error agent_status."""
+        from app.database import Base
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            svc = _make_service_no_api()
+            session = svc.create_session()
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="view_plan", plan_id=9999, raw_message="계획 보여줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "계획 보여줘", db)
+
+            error_events = [
+                e for e in events
+                if e["type"] == "agent_status" and e["data"]["status"] == "error"
+            ]
+            assert len(error_events) >= 1
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)
+
+    def test_view_plan_sets_session_state(self):
+        """view_plan must update session.last_plan and session.last_saved_plan_id."""
+        from app.database import Base
+        from app.models import TravelPlan as TravelPlanModel
+        from datetime import date
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan = TravelPlanModel(
+                destination="로마",
+                start_date=date(2026, 9, 1),
+                end_date=date(2026, 9, 6),
+                budget=2500000.0,
+            )
+            db.add(plan)
+            db.commit()
+            db.refresh(plan)
+            plan_id = plan.id
+
+            svc = _make_service_no_api()
+            session = svc.create_session()
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="view_plan", plan_id=plan_id, raw_message="로마 계획 보여줘"
+            )):
+                _collect_events_with_db(svc, session.session_id, "로마 계획 보여줘", db)
+
+            assert session.last_saved_plan_id == plan_id
+            assert session.last_plan is not None
+            assert session.last_plan["destination"] == "로마"
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)
+
+    def test_view_plan_secretary_done_status(self):
+        """view_plan must emit a secretary done agent_status event on success."""
+        from app.database import Base
+        from app.models import TravelPlan as TravelPlanModel
+        from datetime import date
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan = TravelPlanModel(
+                destination="암스테르담",
+                start_date=date(2026, 10, 1),
+                end_date=date(2026, 10, 4),
+                budget=1800000.0,
+            )
+            db.add(plan)
+            db.commit()
+            db.refresh(plan)
+            plan_id = plan.id
+
+            svc = _make_service_no_api()
+            session = svc.create_session()
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="view_plan", plan_id=plan_id, raw_message="계획 보여줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "계획 보여줘", db)
+
+            secretary_done = next(
+                (
+                    e for e in events
+                    if e["type"] == "agent_status"
+                    and e["data"]["agent"] == "secretary"
+                    and e["data"]["status"] == "done"
+                ),
+                None,
+            )
+            assert secretary_done is not None
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)


### PR DESCRIPTION
## Evolve Run #83
- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: GREEN
- **Task**: #60 - Chat: `view_plan` intent handler — load saved plan into dashboard by name/ID
- **QA**: pass
- **Tests**: 1247/1247

Closes #46

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #60 view_plan intent handler; health GREEN; 1241/1241 tests pass |
| 📐 Architect | ⏭️ | Skipped (backlog_ready_count=2 ≥ 2) |
| 🔨 Builder | ✅ | _handle_view_plan: fetches TravelPlan by exact plan_id (db.get) or destination ilike substring; emits plan_update + secretary done; 6 new tests (TestViewPlan) |
| 🧪 QA | ✅ | 1247/1247 passed; lint clean; done criteria met; no regressions |
| 📝 Reporter | ✅ | This PR |

🤖 Auto-generated by Evolve Pipeline