### PR TITLE
improvement: Chat dashboard Place Scout results dedicated persistent section (#69)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -12,12 +12,6 @@ _(없음)_
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
 
-- [ ] #69 - Chat dashboard: Place Scout results dedicated persistent section [improvement]
-  - ref: markdowns/feat-chat-dashboard.md
-  - files: src/app/static/chat.js, src/app/static/index.html, tests/test_frontend.py
-  - done: `_lastPlaces` cache (mirrors `_lastHotels`/`_lastFlights`); `#places-section` rendered below Hotels/Flights; persists across plan_update calls; `_refreshPlanSearchSections` updated to include places; tests in test_frontend.py
-  - gh: #65
-
 - [ ] #70 - Chat: restore message bubbles from DB after SSE reconnect [improvement]
   - ref: markdowns/feat-chat-dashboard.md (SSE reconnect + session restore)
   - depends: #66
@@ -114,6 +108,7 @@ _(없음)_
 - [x] #66 - Chat session: persist conversation history to SQLite [improvement] — 2026-04-05
 - [x] #67 - Chat: `refine_plan` intent handler — AI plan refinement via chat [feature] — 2026-04-05
 - [x] #68 - Chat: `delete_expense` intent handler [feature] — 2026-04-05
+- [x] #69 - Chat dashboard: Place Scout results dedicated persistent section [improvement] — 2026-04-05
 
 ### Phase 9: User Experience & Polish (remaining, completed)
 - [x] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature] — 2026-04-04
@@ -126,5 +121,5 @@ _(없음)_
 ## Metrics
 
 - Velocity: 1 task/run
-- Total tasks: 68 done, 4 ready (0 in progress)
+- Total tasks: 69 done, 2 ready (0 in progress)
 - Phase: 10 (Chat + Multi-Agent Dashboard)

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,11 +1,11 @@
 {
-  "last_updated": "2026-04-05T12:00:00Z",
+  "last_updated": "2026-04-05T13:00:00Z",
   "summary": {
-    "total_runs": 100,
-    "total_commits": 100,
-    "total_tests": 1364,
-    "tasks_completed": 68,
-    "tasks_remaining": 4,
+    "total_runs": 101,
+    "total_commits": 101,
+    "total_tests": 1371,
+    "tasks_completed": 69,
+    "tasks_remaining": 3,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
     "health": "GREEN"
   },
@@ -48,11 +48,11 @@
     },
     {
       "date": "2026-04-05",
-      "runs": 8,
-      "tasks_completed": 8,
-      "tests_passed": 1364,
+      "runs": 9,
+      "tasks_completed": 9,
+      "tests_passed": 1371,
       "tests_failed": 0,
-      "commits": 8,
+      "commits": 9,
       "health": "GREEN"
     }
   ],
@@ -69,10 +69,10 @@
     "health": "GREEN"
   },
   "last_evolve": {
-    "timestamp": "2026-04-05T12:00:00Z",
-    "run_id": "2026-04-05-1200",
-    "task": "#68 - Chat: delete_expense intent handler",
-    "tests_passed": 1364,
+    "timestamp": "2026-04-05T13:00:00Z",
+    "run_id": "2026-04-05-1300",
+    "task": "#69 - Chat dashboard: Place Scout results dedicated persistent section",
+    "tests_passed": 1371,
     "tests_failed": 0,
     "health": "GREEN"
   }

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,8 +7,8 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 100,
-    "successful_runs": 95,
+    "total_runs": 101,
+    "successful_runs": 96,
     "failed_runs": 0,
     "success_rate": 1.0,
     "budget_remaining": 1.0,
@@ -653,10 +653,10 @@
   ],
   "consecutive_qa_failures": 0,
   "history_tail": {
-    "run_id": "2026-04-05-1200",
-    "task": "#68 - Chat: delete_expense intent handler",
+    "run_id": "2026-04-05-1300",
+    "task": "#69 - Chat dashboard: Place Scout results dedicated persistent section",
     "result": "success",
-    "tests_passed": 1364,
-    "tests_total": 1364
+    "tests_passed": 1371,
+    "tests_total": 1371
   }
 }

--- a/observability/logs/2026-04-05/run-13-00.json
+++ b/observability/logs/2026-04-05/run-13-00.json
@@ -1,0 +1,61 @@
+{
+  "trace": {
+    "run_id": "2026-04-05-1300",
+    "timestamp": "2026-04-05T13:00:00Z",
+    "phase": "Phase 10",
+    "health": "GREEN",
+    "task": "#69 - Chat dashboard: Place Scout results dedicated persistent section",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "pass",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #69. Health GREEN. 1364/1364 tests passing. Architect skipped (Ready >= 2)."
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "backlog_ready_count=2 >= 2, skipped"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "Added _lastPlaces cache; _placeScoutCardHtml helper; _refreshPlanSearchSections updated to create/show/hide #plan-places-section; handleSearchResults stores results.places in _lastPlaces. 7 new tests in TestPlaceScoutPersistentSection. All 1371 tests pass."
+    },
+    {
+      "agent": "qa",
+      "status": "pass",
+      "detail": "1371/1371 passed in 22.17s. ruff clean. Done criteria met. No regressions. No secrets."
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Writing logs, updating status/backlog/budget, creating PR"
+    }
+  ],
+  "ltes": {
+    "latency": {
+      "total_duration_ms": 22170
+    },
+    "traffic": {
+      "commits": 1,
+      "lines_added": 57,
+      "lines_removed": 11,
+      "files_changed": 2
+    },
+    "errors": {
+      "test_failures": 0,
+      "fix_attempts": 0
+    },
+    "saturation": {
+      "backlog_remaining": 3
+    }
+  }
+}

--- a/src/app/static/chat.js
+++ b/src/app/static/chat.js
@@ -13,6 +13,7 @@ let _currentPlanBudget = 0;
 // Persisted search result data — survive plan updates so sections stay visible
 let _lastHotels = null;
 let _lastFlights = null;
+let _lastPlaces = null;
 
 // ---------------------------------------------------------------------------
 // SSE reconnect — exponential backoff configuration
@@ -395,7 +396,19 @@ function _flightCardHtml(f) {
   </div>`;
 }
 
-// Appends or refreshes dedicated #plan-hotels-section / #plan-flights-section inside panel.
+function _placeScoutCardHtml(p) {
+  return `<div class="search-result-card">
+    <div style="display:flex;justify-content:space-between;align-items:center">
+      <strong>${escHtml(p.name)}</strong>
+      ${p.estimated_cost ? `<span class="price-tag">$${p.estimated_cost}</span>` : ''}
+    </div>
+    ${p.category ? `<div class="meta">${escHtml(p.category)}</div>` : ''}
+    ${p.address ? `<div class="meta" style="font-size:.75rem">${escHtml(p.address)}</div>` : ''}
+  </div>`;
+}
+
+// Appends or refreshes dedicated #plan-hotels-section / #plan-flights-section /
+// #plan-places-section inside panel.
 // Each section is hidden when there is no data and visible when data is present.
 function _refreshPlanSearchSections(panel) {
   if (!panel) return;
@@ -430,6 +443,22 @@ function _refreshPlanSearchSections(panel) {
     flightsEl.style.display = '';
   } else if (flightsEl) {
     flightsEl.style.display = 'none';
+  }
+
+  // Places section (below Hotels and Flights)
+  let placesEl = panel.querySelector('#plan-places-section');
+  if (_lastPlaces && _lastPlaces.length) {
+    if (!placesEl) {
+      placesEl = document.createElement('div');
+      placesEl.id = 'plan-places-section';
+      placesEl.className = 'plan-search-section';
+      panel.appendChild(placesEl);
+    }
+    placesEl.innerHTML = `<div class="section-title">📍 Places</div>` +
+      _lastPlaces.map(p => _placeScoutCardHtml(p)).join('');
+    placesEl.style.display = '';
+  } else if (placesEl) {
+    placesEl.style.display = 'none';
   }
 }
 
@@ -551,12 +580,8 @@ function handleSearchResults(data) {
     _lastFlights = results.flights;
     itemsHtml = results.flights.map(f => _flightCardHtml(f)).join('');
   } else if (data.type === 'places' && results.places) {
-    itemsHtml = results.places.map(p =>
-      `<div class="search-result-card">
-        <strong>${escHtml(p.name)}</strong>
-        ${p.category ? `<div class="meta">${escHtml(p.category)}</div>` : ''}
-      </div>`
-    ).join('');
+    _lastPlaces = results.places;
+    itemsHtml = results.places.map(p => _placeScoutCardHtml(p)).join('');
   } else if (data.type === 'budget') {
     const cats = [
       {key: 'accommodation', label: '🏨 숙소'},
@@ -587,17 +612,10 @@ function handleSearchResults(data) {
     detailEl.style.display = 'none'; // collapsed by default; toggle on ▾ click
   }
 
-  // Update plan-panel: hotels/flights get dedicated persistent sections;
-  // other types (places) replace content when no day cards are present.
+  // Update plan-panel: hotels/flights/places get dedicated persistent sections.
   const planPanel = document.getElementById('plan-panel');
-  if (data.type === 'hotels' || data.type === 'flights') {
+  if (data.type === 'hotels' || data.type === 'flights' || data.type === 'places') {
     _refreshPlanSearchSections(planPanel);
-  } else {
-    const hasDayCards = planPanel && planPanel.querySelector('.day-card');
-    if (planPanel && !hasDayCards) {
-      const typeLabel = data.type === 'places' ? '📍 Places' : data.type;
-      planPanel.innerHTML = `<div class="section-title">${typeLabel}</div>${itemsHtml}`;
-    }
   }
 }
 

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-05T12:00:00Z (Evolve Run #92)
-Run count: 99
+Last run: 2026-04-05T13:00:00Z (Evolve Run #93)
+Run count: 100
 Phase: Phase 10: Chat + Multi-Agent Dashboard
 Health: GREEN
 Error Budget: HEALTHY
-Tasks completed: 68
+Tasks completed: 69
 Current focus: Phase 10 (Chat + Multi-Agent Dashboard)
-Next planned: #69 Chat dashboard: Place Scout results dedicated persistent section
+Next planned: #70 Chat: restore message bubbles from DB after SSE reconnect
 
 ## LTES Snapshot
 
-- Latency: ~21640ms (pytest 1364 tests)
-- Traffic: 45 commits/24h
-- Errors: 0 test failures (1364/1364 pass), error_rate=0.0%
-- Saturation: 4 tasks ready
+- Latency: ~22170ms (pytest 1371 tests)
+- Traffic: 46 commits/24h
+- Errors: 0 test failures (1371/1371 pass), error_rate=0.0%
+- Saturation: 3 tasks ready
 
 ## Phase Transition
 
@@ -29,6 +29,15 @@ Next planned: #69 Chat dashboard: Place Scout results dedicated persistent secti
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #93 — 2026-04-05T13:00:00Z
+- **Task**: #69 - Chat dashboard: Place Scout results dedicated persistent section
+- **Result**: GREEN ✓ (QA pass)
+- **Tests**: 1371/1371 passed (+7 new: TestPlaceScoutPersistentSection class, tests/test_frontend.py)
+- **Files changed**: src/app/static/chat.js (+57/-11), tests/test_frontend.py (+7 tests)
+- **Builder note**: Added `_lastPlaces` cache (mirrors `_lastHotels`/`_lastFlights`); `_placeScoutCardHtml` helper renders place cards with name, category, address, estimated_cost; `_refreshPlanSearchSections` updated to create/show/hide `#plan-places-section` below Hotels and Flights; `handleSearchResults` stores `results.places` in `_lastPlaces` and calls `_refreshPlanSearchSections`. Places section persists across `plan_update` calls.
+- **LTES**: L=22170ms T=1 commit E=0.0% S=3 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✓ → reporter ✓
 
 ### Evolve Run #92 — 2026-04-05T12:00:00Z
 - **Task**: #68 - Chat: `delete_expense` intent handler

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -267,3 +267,45 @@ class TestSseReconnect:
         resp = client.get(f"/chat/sessions/{session_id}")
         data = resp.json()
         assert "last_plan" in data
+
+
+class TestPlaceScoutPersistentSection:
+    """Task #69: Place Scout results — dedicated persistent #places-section."""
+
+    def test_chat_js_has_last_places_cache(self, client: TestClient):
+        """chat.js declares _lastPlaces variable for persisting place results."""
+        content = client.get("/static/chat.js").text
+        assert "_lastPlaces" in content
+
+    def test_chat_js_refresh_includes_places_section(self, client: TestClient):
+        """_refreshPlanSearchSections handles #plan-places-section."""
+        content = client.get("/static/chat.js").text
+        assert "plan-places-section" in content
+
+    def test_chat_js_places_section_has_title(self, client: TestClient):
+        """Places section renders with a section title (Places)."""
+        content = client.get("/static/chat.js").text
+        assert "📍 Places" in content
+
+    def test_chat_js_places_stored_in_last_places(self, client: TestClient):
+        """handleSearchResults assigns results.places to _lastPlaces."""
+        content = client.get("/static/chat.js").text
+        assert "_lastPlaces = results.places" in content
+
+    def test_chat_js_places_calls_refresh_sections(self, client: TestClient):
+        """handleSearchResults calls _refreshPlanSearchSections for places type."""
+        content = client.get("/static/chat.js").text
+        # places must be included in the refresh condition
+        assert "places" in content
+        assert "_refreshPlanSearchSections" in content
+
+    def test_chat_js_place_scout_card_html(self, client: TestClient):
+        """chat.js has _placeScoutCardHtml helper function."""
+        content = client.get("/static/chat.js").text
+        assert "_placeScoutCardHtml" in content
+
+    def test_chat_js_refresh_sections_handles_places(self, client: TestClient):
+        """_refreshPlanSearchSections function body references _lastPlaces."""
+        content = client.get("/static/chat.js").text
+        assert "_lastPlaces" in content
+        assert "_refreshPlanSearchSections" in content


### PR DESCRIPTION
## Evolve Run #93

- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: GREEN
- **Task**: #69 - Chat dashboard: Place Scout results dedicated persistent section
- **QA**: pass
- **Tests**: 1371/1371 passed (+7 new)

Closes #65

### Agent Activity

| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #69. Health GREEN. 1364/1364 tests passing. |
| 📐 Architect | ⏭️ | Skipped (backlog_ready_count=2 ≥ 2) |
| 🔨 Builder | ✅ | `_lastPlaces` cache; `_placeScoutCardHtml` helper; `_refreshPlanSearchSections` updated to create/show/hide `#plan-places-section`; `handleSearchResults` stores `results.places`. 2 files changed (+57/-11). 7 new tests. |
| 🧪 QA | ✅ | 1371/1371 passed in 22.17s. ruff clean. All done criteria met. |
| 📝 Reporter | ✅ | This PR |

🤖 Auto-generated by Evolve Pipeline