### PR TITLE
feat(wip): #91 share_plan intent backend — QA fail (frontend missing)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -6,7 +6,15 @@
 
 ## In Progress
 
-_(없음)_
+- [ ] #91 - Chat: `share_plan` intent — generate shareable plan link via chat [feature]
+  - ref: markdowns/feat-chat-dashboard.md
+  - files: src/app/chat.py, tests/test_chat.py, src/app/static/chat.js (or index.html)
+  - done: "이 계획 공유해줘" → secretary emits plan_shared event with share_url + share_token; frontend shows copiable URL in chat/dashboard; graceful error if no saved plan; 2+ tests
+  - gh: #112
+  - ❌ QA fail (Run #116, 2026-04-06): Backend complete (plan_shared event + token), 10 tests pass. Blockers:
+    1. **[HIGH]** Frontend handler missing — no JS handles plan_shared SSE event; done criteria requires copiable URL in chat/dashboard
+    2. **[MEDIUM]** All 10 tests mock extract_intent (Constraint #10) — add ≥1 test with real intent extraction path
+    3. **[MEDIUM]** @playwright/test not installed — pre-existing E2E blocker
 
 ## Ready
   - **문제**: Plans 페이지가 빈 껍데기, "Create your first trip!" 링크만 존재. 사용자가 버튼을 조작하는 게 아니라 채팅만으로 모든 여행 관리가 되어야 함
@@ -15,12 +23,6 @@ _(없음)_
   - done: 사이트 접속 시 바로 채팅 인터페이스; 빈 상태에서 가이드/예시 표시; Plans 탭은 저장된 계획 목록만; 시각적으로 현대적; 기존 E2E 깨지지 않음
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
-
-- [ ] #91 - Chat: `share_plan` intent — generate shareable plan link via chat [feature]
-  - ref: markdowns/feat-chat-dashboard.md
-  - files: src/app/chat.py, tests/test_chat.py
-  - done: "이 계획 공유해줘" → secretary emits plan_shared event with share_url + share_token; frontend shows copiable URL in chat/dashboard; graceful error if no saved plan; 2+ tests
-  - gh: #112
 
 - [ ] #92 - E2E: share_plan Playwright scenarios [test]
   - ref: markdowns/feat-chat-dashboard.md

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,13 +1,13 @@
 {
-  "last_updated": "2026-04-06T13:00:00Z",
+  "last_updated": "2026-04-06T14:00:00Z",
   "summary": {
-    "total_runs": 132,
-    "total_commits": 122,
-    "total_tests": 1499,
+    "total_runs": 134,
+    "total_commits": 123,
+    "total_tests": 1509,
     "tasks_completed": 92,
-    "tasks_remaining": 2,
+    "tasks_remaining": 6,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
-    "health": "GREEN"
+    "health": "YELLOW"
   },
   "daily_trend": [
     {
@@ -57,12 +57,12 @@
     },
     {
       "date": "2026-04-06",
-      "runs": 3,
+      "runs": 4,
       "tasks_completed": 1,
-      "tests_passed": 1499,
+      "tests_passed": 1509,
       "tests_failed": 0,
-      "commits": 29,
-      "health": "GREEN"
+      "commits": 30,
+      "health": "YELLOW"
     }
   ],
   "ltes_7d_avg": {
@@ -78,11 +78,12 @@
     "health": "GREEN"
   },
   "last_evolve": {
-    "timestamp": "2026-04-06T11:30:00Z",
-    "run_id": "2026-04-06-1130",
-    "task": "#98 - Frontend: chat-first UX 전면 개편 — Jarvis 컨셉",
-    "tests_passed": 1499,
+    "timestamp": "2026-04-06T14:00:00Z",
+    "run_id": "2026-04-06-1400",
+    "task": "#91 - Chat: share_plan intent — generate shareable plan link via chat",
+    "tests_passed": 1509,
     "tests_failed": 0,
-    "health": "GREEN"
+    "health": "YELLOW",
+    "qa_verdict": "fail"
   }
 }

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,11 +7,11 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 133,
+    "total_runs": 134,
     "successful_runs": 128,
-    "failed_runs": 0,
-    "success_rate": 0.962,
-    "budget_remaining": 1.0,
+    "failed_runs": 1,
+    "success_rate": 0.955,
+    "budget_remaining": 0.95,
     "status": "HEALTHY"
   },
   "policy": {
@@ -651,7 +651,7 @@
       "tests_total": 1241
     }
   ],
-  "consecutive_qa_failures": 0,
+  "consecutive_qa_failures": 1,
   "history_tail": {
     "run_id": "monitor-2026-04-06-1300",
     "task": "monitor",

--- a/observability/logs/2026-04-06/run-14-00.json
+++ b/observability/logs/2026-04-06/run-14-00.json
@@ -1,0 +1,77 @@
+{
+  "trace": {
+    "run_id": "2026-04-06-1400",
+    "timestamp": "2026-04-06T14:00:00Z",
+    "phase": "Phase 10: Chat + Multi-Agent Dashboard",
+    "health": "YELLOW",
+    "task": "#91 - Chat: `share_plan` intent — generate shareable plan link via chat",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "fail",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #91 share_plan intent; health GREEN; no fix/architect needed"
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "backlog_ready_count=6 >= 2; skipped per policy"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "Implemented share_plan intent: secretary emits plan_shared event with share_url + share_token. 10 new tests (TestSharePlan). 1509 passing total."
+    },
+    {
+      "agent": "qa",
+      "status": "fail",
+      "detail": "done_criteria_met=fail (frontend handler missing), integration_test_quality=fail (extract_intent mocked in all 10 new tests), e2e_integration=fail (playwright not installed — pre-existing). Tests 1509/1509 pass, lint clean."
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Recording results, updating state files, creating PR"
+    }
+  ],
+  "ltes": {
+    "latency": {
+      "total_duration_ms": 26890
+    },
+    "traffic": {
+      "commits": 1,
+      "lines_added": 121,
+      "lines_removed": 2,
+      "files_changed": 2
+    },
+    "errors": {
+      "test_failures": 0,
+      "qa_failures": 3,
+      "fix_attempts": 0
+    },
+    "saturation": {
+      "backlog_remaining": 6
+    }
+  },
+  "qa_checks": {
+    "all_tests_pass": "pass",
+    "new_tests_exist": "pass",
+    "lint_clean": "pass",
+    "done_criteria_met": "fail",
+    "no_regressions": "pass",
+    "integration_test_quality": "fail",
+    "e2e_integration": "fail",
+    "no_secrets_leaked": "pass"
+  },
+  "issues": [
+    "Frontend handler for plan_shared event is missing — done criteria requires copiable URL in chat/dashboard",
+    "All 10 new tests mock extract_intent, bypassing real intent routing (Constraint #10)",
+    "E2E Playwright cannot run — @playwright/test not installed (pre-existing)"
+  ]
+}

--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -33,7 +33,7 @@ _DEFAULT_DEPARTURE = "Seoul"  # default origin for flight search
 
 
 class Intent(BaseModel):
-    action: str  # create_plan | modify_day | refine_plan | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | delete_plan | view_plan | add_expense | update_expense | update_plan | get_expense_summary | delete_expense | list_expenses | copy_plan | get_weather | reset_conversation | add_day_note | suggest_improvements | remove_place | add_place | general
+    action: str  # create_plan | modify_day | refine_plan | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | delete_plan | view_plan | add_expense | update_expense | update_plan | get_expense_summary | delete_expense | list_expenses | copy_plan | get_weather | reset_conversation | add_day_note | suggest_improvements | remove_place | add_place | share_plan | general
     destination: Optional[str] = None
     start_date: Optional[str] = None
     end_date: Optional[str] = None
@@ -151,7 +151,7 @@ class ChatService:
 User message: "{message}"
 
 Return a JSON object with these fields:
-- action: one of "create_plan", "modify_day", "refine_plan", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "add_expense", "update_expense", "update_plan", "get_expense_summary", "delete_expense", "list_expenses", "copy_plan", "get_weather", "reset_conversation", "add_day_note", "suggest_improvements", "remove_place", "add_place", "general"
+- action: one of "create_plan", "modify_day", "refine_plan", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "add_expense", "update_expense", "update_plan", "get_expense_summary", "delete_expense", "list_expenses", "copy_plan", "get_weather", "reset_conversation", "add_day_note", "suggest_improvements", "remove_place", "add_place", "share_plan", "general"
 - destination: destination city/country if mentioned or inferred from conversation context, else null
 - start_date: start date in YYYY-MM-DD if mentioned or inferred from context, else null
 - end_date: end date in YYYY-MM-DD if mentioned or inferred from context, else null
@@ -175,6 +175,7 @@ Return a JSON object with these fields:
 - Use action "add_place" when user wants to add/append a custom place to a specific day (e.g. "1일차에 서울숲 추가해줘", "Day 2에 경복궁 넣어줘", "3일차에 맛집 추가", "add Gyeongbokgung to day 1", "Day 3에 카페 추가"); set day_number to the referenced day, query to the place name, and place_category to the category if mentioned (e.g. "맛집" → "food", "카페" → "cafe", "관광지" → "sightseeing"), else null
 - place_index: 1-based index of the place to remove within the day's places list, if an ordinal position is mentioned (e.g. "첫 번째" → 1, "두 번째" → 2); null if removing by name or unspecified
 - place_category: category for the place to add (e.g. "sightseeing", "food", "cafe", "museum", "park", "landmark"); null if not specified
+- Use action "share_plan" when user wants to share or get a shareable link for the current or a specific travel plan (e.g. "이 계획 공유해줘", "공유 링크 만들어줘", "친구한테 공유하고 싶어", "share this plan", "get a shareable link", "링크 공유", "공유"); set plan_id if a specific plan is referenced
 - raw_message: the exact original message"""
 
             client = genai.Client(api_key=self._api_key)
@@ -343,6 +344,9 @@ Return a JSON object with these fields:
                 yield _track_and_collect(event)
         elif intent.action == "add_place":
             async for event in self._handle_add_place(intent, session, db):
+                yield _track_and_collect(event)
+        elif intent.action == "share_plan":
+            async for event in self._handle_share_plan(intent, session, db):
                 yield _track_and_collect(event)
         else:  # general
             async for event in self._handle_general(intent, session):
@@ -2108,6 +2112,97 @@ Return a JSON object with these fields:
             yield {
                 "type": "chat_chunk",
                 "data": {"text": f"여행 계획 복사 중 오류가 발생했습니다: {exc}"},
+            }
+
+    async def _handle_share_plan(
+        self,
+        intent: Intent,
+        session: "ChatSession",
+        db: Optional["Session"] = None,
+    ) -> AsyncGenerator[dict, None]:
+        """Generate a shareable link for the current or specified travel plan."""
+        yield {
+            "type": "agent_status",
+            "data": {"agent": "secretary", "status": "working", "message": "공유 링크 생성 중..."},
+        }
+        await asyncio.sleep(0)
+
+        if db is None:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "secretary", "status": "error", "message": "DB가 연결되지 않았습니다"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": "공유 링크를 생성하려면 DB 연결이 필요합니다."},
+            }
+            return
+
+        plan_id: Optional[int] = intent.plan_id or session.last_saved_plan_id
+        if plan_id is None:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "secretary", "status": "error", "message": "저장된 계획이 없습니다"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": "공유할 여행 계획이 없습니다. 먼저 계획을 저장해주세요."},
+            }
+            return
+
+        try:
+            import secrets as _secrets
+
+            from app.models import TravelPlan as TravelPlanModel
+
+            plan: Optional[TravelPlanModel] = db.get(TravelPlanModel, plan_id)
+            if plan is None:
+                yield {
+                    "type": "agent_status",
+                    "data": {"agent": "secretary", "status": "error", "message": "계획을 찾을 수 없습니다"},
+                }
+                yield {
+                    "type": "chat_chunk",
+                    "data": {"text": f"Plan #{plan_id}을 찾을 수 없습니다."},
+                }
+                return
+
+            if not plan.is_shared or not plan.share_token:
+                plan.share_token = _secrets.token_urlsafe(32)
+                plan.is_shared = True
+                db.commit()
+                db.refresh(plan)
+
+            import os as _os
+            base_url = _os.getenv("APP_BASE_URL", "").rstrip("/")
+            share_url = f"{base_url}/travel-plans/shared/{plan.share_token}"
+
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "secretary", "status": "done", "message": "공유 링크 생성 완료!"},
+            }
+            yield {
+                "type": "plan_shared",
+                "data": {
+                    "plan_id": plan.id,
+                    "share_token": plan.share_token,
+                    "share_url": share_url,
+                },
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"공유 링크가 생성되었습니다: {share_url}"},
+            }
+
+        except Exception as exc:
+            logger.error("_handle_share_plan: failed — %s: %s", type(exc).__name__, exc, exc_info=True)
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "secretary", "status": "error", "message": "공유 링크 생성 실패"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"공유 링크 생성 중 오류가 발생했습니다: {exc}"},
             }
 
     async def _handle_get_weather(

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-06T11:30:00Z (Evolve Run #115)
-Run count: 131
+Last run: 2026-04-06T14:00:00Z (Evolve Run #116)
+Run count: 134
 Phase: Phase 10: Chat + Multi-Agent Dashboard — P0 Critical UX Fixes
-Health: GREEN
+Health: YELLOW
 Error Budget: HEALTHY
 Tasks completed: 92 (#97 chat general handler + #98 chat-first UX)
-Current focus: P0 Critical UX Fixes (user feedback 2026-04-06)
-Next planned: #91 Chat: `share_plan` intent — generate shareable plan link via chat
+Current focus: #91 share_plan intent (QA failed — frontend handler missing)
+Next planned: #91 retry (frontend plan_shared handler + real-intent test)
 
 ## LTES Snapshot
 
-- Latency: 41000ms (monitor run; pytest 24.27s)
+- Latency: 26890ms (pytest 26.89s)
 - Traffic: 29 commits/24h
-- Errors: 0 test failures (1499/1499 pass), error_rate=0.0%
-- Saturation: 2 tasks ready
+- Errors: 0 test failures (1509/1509 pass), QA fail (done_criteria/integration_test_quality/e2e), error_rate=0.75%
+- Saturation: 6 tasks ready
 
 ## Phase Transition
 
@@ -29,6 +29,18 @@ Next planned: #91 Chat: `share_plan` intent — generate shareable plan link via
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #116 — 2026-04-06T14:00:00Z
+- **Task**: #91 - Chat: `share_plan` intent — generate shareable plan link via chat
+- **Result**: YELLOW ✗ (QA fail)
+- **Tests**: 1509/1509 passed (10 new TestSharePlan), lint clean
+- **QA failures**:
+  - `done_criteria_met` FAIL — frontend plan_shared handler missing; no JS/HTML handles plan_shared SSE event or renders share_url
+  - `integration_test_quality` FAIL — all 10 new tests mock extract_intent (Constraint #10 violation)
+  - `e2e_integration` FAIL — @playwright/test not installed (pre-existing)
+- **Files changed**: src/app/chat.py (+121/-2), tests/test_chat.py
+- **LTES**: L=26890ms T=1 commit E=0 test failures S=6 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✗ → reporter ✓
 
 ### Monitor Run #127 — 2026-04-06T13:00:00Z
 - **Task**: monitor

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -4952,6 +4952,25 @@ class TestListExpenses:
 # Task #77: copy_plan intent handler
 # ---------------------------------------------------------------------------
 
+def _seed_bare_plan(db):
+    """Insert a minimal TravelPlan without itinerary; return plan_id."""
+    from app.models import TravelPlan as TravelPlanModel
+    from datetime import date as date_type
+
+    plan = TravelPlanModel(
+        destination="도쿄",
+        start_date=date_type(2026, 5, 1),
+        end_date=date_type(2026, 5, 4),
+        budget=2000000.0,
+        interests="food",
+        status="draft",
+    )
+    db.add(plan)
+    db.commit()
+    db.refresh(plan)
+    return plan.id
+
+
 def _seed_plan_with_itinerary(db):
     """Insert a TravelPlan with one DayItinerary and one Place; return plan_id."""
     from app.models import DayItinerary as DayItineraryModel, Place as PlaceModel, TravelPlan as TravelPlanModel
@@ -6763,3 +6782,242 @@ class TestAddPlace:
         finally:
             db.close()
             Base.metadata.drop_all(bind=engine)
+
+
+# ---------------------------------------------------------------------------
+# Task #91 — share_plan intent
+# ---------------------------------------------------------------------------
+
+class TestSharePlan:
+    """secretary emits plan_shared event with share_url + share_token when user wants to share a plan."""
+
+    def test_share_plan_activates_secretary(self):
+        """share_plan intent must activate the secretary agent."""
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan_id = _seed_bare_plan(db)
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_saved_plan_id = plan_id
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="share_plan", raw_message="이 계획 공유해줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "이 계획 공유해줘", db)
+
+            agent_names = {e["data"]["agent"] for e in events if e["type"] == "agent_status"}
+            assert "secretary" in agent_names
+        finally:
+            db.close()
+            from app.database import Base
+            Base.metadata.drop_all(bind=engine)
+
+    def test_share_plan_emits_plan_shared_event(self):
+        """share_plan must emit a plan_shared event."""
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan_id = _seed_bare_plan(db)
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_saved_plan_id = plan_id
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="share_plan", raw_message="공유해줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "공유해줘", db)
+
+            shared_events = [e for e in events if e["type"] == "plan_shared"]
+            assert len(shared_events) == 1
+        finally:
+            db.close()
+            from app.database import Base
+            Base.metadata.drop_all(bind=engine)
+
+    def test_share_plan_event_contains_share_url_and_token(self):
+        """plan_shared event must contain share_url and share_token fields."""
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan_id = _seed_bare_plan(db)
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_saved_plan_id = plan_id
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="share_plan", raw_message="공유 링크 줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "공유 링크 줘", db)
+
+            evt = next(e for e in events if e["type"] == "plan_shared")
+            assert "share_url" in evt["data"]
+            assert "share_token" in evt["data"]
+            assert evt["data"]["share_token"] is not None
+            assert len(evt["data"]["share_token"]) > 0
+        finally:
+            db.close()
+            from app.database import Base
+            Base.metadata.drop_all(bind=engine)
+
+    def test_share_plan_sets_is_shared_in_db(self):
+        """share_plan must set plan.is_shared = True and store a share_token in the DB."""
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan_id = _seed_bare_plan(db)
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_saved_plan_id = plan_id
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="share_plan", raw_message="공유해줘"
+            )):
+                _collect_events_with_db(svc, session.session_id, "공유해줘", db)
+
+            from app.models import TravelPlan as TravelPlanModel
+            db.expire_all()
+            plan = db.get(TravelPlanModel, plan_id)
+            assert plan.is_shared is True
+            assert plan.share_token is not None
+        finally:
+            db.close()
+            from app.database import Base
+            Base.metadata.drop_all(bind=engine)
+
+    def test_share_plan_no_saved_plan_emits_error(self):
+        """share_plan without a saved plan ID must emit secretary error and helpful chat_chunk."""
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            # No last_saved_plan_id set, no intent.plan_id
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="share_plan", raw_message="계획 공유해줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "계획 공유해줘", db)
+
+            sec_error_events = [
+                e for e in events
+                if e["type"] == "agent_status"
+                and e["data"]["agent"] == "secretary"
+                and e["data"]["status"] == "error"
+            ]
+            assert len(sec_error_events) >= 1
+
+            chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+            assert len(chat_chunks) >= 1
+            all_text = " ".join(e["data"]["text"] for e in chat_chunks)
+            assert "저장" in all_text or "계획" in all_text
+        finally:
+            db.close()
+            from app.database import Base
+            Base.metadata.drop_all(bind=engine)
+
+    def test_share_plan_via_intent_plan_id(self):
+        """share_plan with explicit plan_id in intent uses that plan even without session.last_saved_plan_id."""
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan_id = _seed_bare_plan(db)
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            # Do NOT set session.last_saved_plan_id
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="share_plan", plan_id=plan_id, raw_message=f"{plan_id}번 계획 공유해줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, f"{plan_id}번 계획 공유해줘", db)
+
+            shared_events = [e for e in events if e["type"] == "plan_shared"]
+            assert len(shared_events) == 1
+            assert shared_events[0]["data"]["plan_id"] == plan_id
+        finally:
+            db.close()
+            from app.database import Base
+            Base.metadata.drop_all(bind=engine)
+
+    def test_share_plan_reuses_existing_token(self):
+        """Calling share_plan twice must return the same token (idempotent)."""
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan_id = _seed_bare_plan(db)
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_saved_plan_id = plan_id
+
+            def _share():
+                with patch.object(svc, "extract_intent", return_value=Intent(
+                    action="share_plan", raw_message="공유해줘"
+                )):
+                    return _collect_events_with_db(svc, session.session_id, "공유해줘", db)
+
+            events1 = _share()
+            events2 = _share()
+
+            token1 = next(e for e in events1 if e["type"] == "plan_shared")["data"]["share_token"]
+            token2 = next(e for e in events2 if e["type"] == "plan_shared")["data"]["share_token"]
+            assert token1 == token2
+        finally:
+            db.close()
+            from app.database import Base
+            Base.metadata.drop_all(bind=engine)
+
+    def test_share_plan_secretary_working_then_done(self):
+        """secretary must transition working → done on successful share."""
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan_id = _seed_bare_plan(db)
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_saved_plan_id = plan_id
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="share_plan", raw_message="공유해줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "공유해줘", db)
+
+            sec_events = [
+                e for e in events
+                if e["type"] == "agent_status" and e["data"]["agent"] == "secretary"
+            ]
+            statuses = [e["data"]["status"] for e in sec_events]
+            assert "working" in statuses
+            assert "done" in statuses
+        finally:
+            db.close()
+            from app.database import Base
+            Base.metadata.drop_all(bind=engine)
+
+    def test_share_plan_emits_chat_chunk(self):
+        """share_plan must emit at least one chat_chunk with the share URL."""
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan_id = _seed_bare_plan(db)
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_saved_plan_id = plan_id
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="share_plan", raw_message="공유해줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "공유해줘", db)
+
+            chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+            assert len(chat_chunks) >= 1
+            all_text = " ".join(e["data"]["text"] for e in chat_chunks)
+            assert "travel-plans/shared" in all_text
+        finally:
+            db.close()
+            from app.database import Base
+            Base.metadata.drop_all(bind=engine)
+
+    def test_intent_extraction_recognizes_share_plan(self):
+        """'이 계획 공유해줘' should map to share_plan action in intent model."""
+        intent = Intent(action="share_plan", raw_message="이 계획 공유해줘")
+        assert intent.action == "share_plan"


### PR DESCRIPTION
## Evolve Run #116

- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: YELLOW
- **Task**: #91 - Chat: \`share_plan\` intent — generate shareable plan link via chat
- **QA**: ❌ fail
- **Tests**: 1509/1509 passed (+10 new TestSharePlan)

### Agent Activity

| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #91; health GREEN; no fix/architect needed |
| 📐 Architect | ⏭️ | Skipped (backlog_ready_count=6 ≥ 2) |
| 🔨 Builder | ✅ | Implemented share_plan handler: secretary emits plan_shared event with share_url + share_token; uses TravelPlan.is_shared/share_token DB fields; idempotent re-share; graceful error if no saved plan; 10 new TestSharePlan tests |
| 🧪 QA | ❌ | done_criteria_met=fail, integration_test_quality=fail, e2e_integration=fail |
| 📝 Reporter | ✅ | This PR |

### QA Failures

| Check | Result | Detail |
|-------|--------|--------|
| all_tests_pass | ✅ | 1509/1509 pass |
| new_tests_exist | ✅ | 10 new tests in TestSharePlan |
| lint_clean | ✅ | ruff — no issues |
| done_criteria_met | ❌ | Frontend plan_shared handler missing; no JS/HTML handles plan_shared SSE event |
| no_regressions | ✅ | All 1499 prior tests pass |
| integration_test_quality | ❌ | All 10 tests mock extract_intent (Constraint #10 violation) |
| e2e_integration | ❌ | @playwright/test not installed (pre-existing) |
| no_secrets_leaked | ✅ | No hardcoded secrets |

### Required Fixes for Next Run
1. **[HIGH]** Add frontend handler in chat.js for \`plan_shared\` SSE event → render copiable \`<input>\` with \`share_url\` in chat bubble and/or dashboard panel
2. **[MEDIUM]** Add ≥1 test that sends natural language message through real intent extraction path (mock Gemini HTTP response, not \`extract_intent\` directly)
3. **[MEDIUM]** Fix \`@playwright/test\` installation to re-enable E2E

🤖 Auto-generated by Evolve Pipeline