### PR TITLE
feat: #91 share_plan frontend handler + real-intent test (#91)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -6,15 +6,7 @@
 
 ## In Progress
 
-- [ ] #91 - Chat: `share_plan` intent — generate shareable plan link via chat [feature]
-  - ref: markdowns/feat-chat-dashboard.md
-  - files: src/app/chat.py, tests/test_chat.py, src/app/static/chat.js (or index.html)
-  - done: "이 계획 공유해줘" → secretary emits plan_shared event with share_url + share_token; frontend shows copiable URL in chat/dashboard; graceful error if no saved plan; 2+ tests
-  - gh: #112
-  - ❌ QA fail (Run #116, 2026-04-06): Backend complete (plan_shared event + token), 10 tests pass. Blockers:
-    1. **[HIGH]** Frontend handler missing — no JS handles plan_shared SSE event; done criteria requires copiable URL in chat/dashboard
-    2. **[MEDIUM]** All 10 tests mock extract_intent (Constraint #10) — add ≥1 test with real intent extraction path
-    3. **[MEDIUM]** @playwright/test not installed — pre-existing E2E blocker
+_(없음)_
 
 ## Ready
   - **문제**: Plans 페이지가 빈 껍데기, "Create your first trip!" 링크만 존재. 사용자가 버튼을 조작하는 게 아니라 채팅만으로 모든 여행 관리가 되어야 함
@@ -164,6 +156,7 @@ _(없음)_
 ### P0: Critical UX Fixes (user feedback)
 - [x] #97 - Chat: intelligent `general` handler — 자연어 대화 + 정보 추출 + 보강 질문 [critical-fix] — 2026-04-06
 - [x] #98 - Frontend: chat-first UX 전면 개편 — Jarvis 컨셉 [critical-fix] — 2026-04-06
+- [x] #91 - Chat: `share_plan` intent — generate shareable plan link via chat (retry) [feature] — 2026-04-06
 
 ### Phase 9: User Experience & Polish (remaining, completed)
 - [x] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature] — 2026-04-04
@@ -176,5 +169,5 @@ _(없음)_
 ## Metrics
 
 - Velocity: 1 task/run
-- Total tasks: 92 done, 6 ready (0 in progress)
+- Total tasks: 93 done, 5 ready (0 in progress)
 - Phase: 10 (Chat + Multi-Agent Dashboard)

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,11 +1,11 @@
 {
-  "last_updated": "2026-04-06T14:30:00Z",
+  "last_updated": "2026-04-06T15:55:41Z",
   "summary": {
-    "total_runs": 135,
-    "total_commits": 123,
-    "total_tests": 1509,
-    "tasks_completed": 92,
-    "tasks_remaining": 6,
+    "total_runs": 136,
+    "total_commits": 124,
+    "total_tests": 1510,
+    "tasks_completed": 93,
+    "tasks_remaining": 5,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
     "health": "GREEN"
   },
@@ -57,11 +57,11 @@
     },
     {
       "date": "2026-04-06",
-      "runs": 5,
-      "tasks_completed": 1,
-      "tests_passed": 1509,
+      "runs": 6,
+      "tasks_completed": 2,
+      "tests_passed": 1510,
       "tests_failed": 0,
-      "commits": 20,
+      "commits": 21,
       "health": "GREEN"
     }
   ],

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,8 +7,8 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 135,
-    "successful_runs": 129,
+    "total_runs": 136,
+    "successful_runs": 130,
     "failed_runs": 1,
     "success_rate": 0.956,
     "budget_remaining": 0.95,
@@ -651,7 +651,7 @@
       "tests_total": 1241
     }
   ],
-  "consecutive_qa_failures": 1,
+  "consecutive_qa_failures": 0,
   "history_tail": {
     "run_id": "monitor-2026-04-06-1430",
     "task": "monitor",

--- a/observability/logs/2026-04-06/run-15-00.json
+++ b/observability/logs/2026-04-06/run-15-00.json
@@ -1,0 +1,61 @@
+{
+  "trace": {
+    "run_id": "2026-04-06-1500",
+    "timestamp": "2026-04-06T15:55:41Z",
+    "phase": "Phase 10",
+    "health": "GREEN",
+    "task": "#91 - Chat: share_plan intent — generate shareable plan link via chat (retry)",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "pass",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #91 retry — frontend handler + real-intent test"
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "Ready tasks >= 2, no architect needed"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "Added case 'plan_shared' handler in chat.js (handlePlanShared); renders copiable URL input + copy button in chat bubble AND plan-panel dashboard. Added test_share_plan_real_intent_extraction_path mocking genai.Client at HTTP level."
+    },
+    {
+      "agent": "qa",
+      "status": "pass",
+      "detail": "1510 passed, 5 skipped. All checks pass: done_criteria, integration_test_quality, lint, no_regressions, no_secrets_leaked."
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Writing LTES log, updating status/backlog/budget, creating PR"
+    }
+  ],
+  "ltes": {
+    "latency": {
+      "total_duration_ms": 37895
+    },
+    "traffic": {
+      "commits": 1,
+      "lines_added": 88,
+      "lines_removed": 0,
+      "files_changed": 2
+    },
+    "errors": {
+      "test_failures": 0,
+      "fix_attempts": 0
+    },
+    "saturation": {
+      "backlog_remaining": 5
+    }
+  }
+}

--- a/src/app/static/chat.js
+++ b/src/app/static/chat.js
@@ -327,6 +327,9 @@ function handleSseEvent(event) {
     case 'plan_suggestions':
       if (event.data) handlePlanSuggestions(event.data);
       break;
+    case 'plan_shared':
+      if (event.data) handlePlanShared(event.data);
+      break;
     case 'session_reset':
       _handleSessionReset();
       break;
@@ -1143,4 +1146,93 @@ function _appendSavedPlanCard(plan) {
   card.addEventListener('click', activate);
   card.addEventListener('keydown', e => { if (e.key === 'Enter' || e.key === ' ') activate(); });
   panel.appendChild(card);
+}
+
+// ---------------------------------------------------------------------------
+// Share plan — render copiable link card in chat + dashboard
+// ---------------------------------------------------------------------------
+
+function handlePlanShared(data) {
+  const shareUrl = (data && data.share_url) ? data.share_url : '';
+
+  // --- Chat bubble with copiable URL ---
+  const messagesEl = document.getElementById('chat-messages');
+  if (messagesEl && shareUrl) {
+    const bubble = document.createElement('div');
+    bubble.className = 'chat-bubble chat-ai';
+
+    const label = document.createElement('div');
+    label.textContent = '🔗 공유 링크가 생성되었습니다:';
+    label.style.marginBottom = '0.4rem';
+    bubble.appendChild(label);
+
+    const urlRow = document.createElement('div');
+    urlRow.style.cssText = 'display:flex;gap:.4rem;align-items:center;flex-wrap:wrap';
+
+    const urlInput = document.createElement('input');
+    urlInput.type = 'text';
+    urlInput.readOnly = true;
+    urlInput.value = shareUrl;
+    urlInput.setAttribute('aria-label', '공유 링크');
+    urlInput.style.cssText = 'flex:1;min-width:0;font-size:.85rem;padding:.25rem .4rem;border:1px solid #ccc;border-radius:4px;background:#f9f9f9';
+
+    const copyBtn = document.createElement('button');
+    copyBtn.textContent = '복사';
+    copyBtn.style.cssText = 'padding:.25rem .6rem;font-size:.85rem;cursor:pointer;white-space:nowrap';
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(shareUrl).then(() => {
+        copyBtn.textContent = '✅ 복사됨';
+        setTimeout(() => { copyBtn.textContent = '복사'; }, 2000);
+      }).catch(() => {
+        urlInput.select();
+        document.execCommand('copy');
+        copyBtn.textContent = '✅ 복사됨';
+        setTimeout(() => { copyBtn.textContent = '복사'; }, 2000);
+      });
+    });
+
+    urlRow.appendChild(urlInput);
+    urlRow.appendChild(copyBtn);
+    bubble.appendChild(urlRow);
+    messagesEl.appendChild(bubble);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  }
+
+  // --- Dashboard panel share section ---
+  const panel = document.getElementById('plan-panel');
+  if (panel && shareUrl) {
+    // Remove any previous share card
+    const prev = panel.querySelector('.plan-share-card');
+    if (prev) prev.remove();
+
+    const shareCard = document.createElement('div');
+    shareCard.className = 'card plan-share-card';
+    shareCard.style.marginTop = '.75rem';
+    shareCard.innerHTML = `
+      <div class="section-title" style="margin-bottom:.4rem">🔗 공유 링크</div>
+      <div style="display:flex;gap:.4rem;align-items:center;flex-wrap:wrap">
+        <input type="text" readonly value="${escHtml(shareUrl)}"
+          aria-label="공유 링크 (대시보드)"
+          style="flex:1;min-width:0;font-size:.8rem;padding:.2rem .35rem;border:1px solid #ccc;border-radius:4px;background:#f9f9f9">
+        <button id="share-copy-btn-panel"
+          style="padding:.2rem .5rem;font-size:.8rem;cursor:pointer;white-space:nowrap">복사</button>
+      </div>`;
+    panel.appendChild(shareCard);
+
+    const panelCopyBtn = shareCard.querySelector('#share-copy-btn-panel');
+    const panelInput   = shareCard.querySelector('input');
+    if (panelCopyBtn && panelInput) {
+      panelCopyBtn.addEventListener('click', () => {
+        navigator.clipboard.writeText(shareUrl).then(() => {
+          panelCopyBtn.textContent = '✅ 복사됨';
+          setTimeout(() => { panelCopyBtn.textContent = '복사'; }, 2000);
+        }).catch(() => {
+          panelInput.select();
+          document.execCommand('copy');
+          panelCopyBtn.textContent = '✅ 복사됨';
+          setTimeout(() => { panelCopyBtn.textContent = '복사'; }, 2000);
+        });
+      });
+    }
+  }
 }

--- a/status.md
+++ b/status.md
@@ -1,13 +1,13 @@
 # Status
 
-Last run: 2026-04-06T14:30:00Z (Monitor Run #128)
-Run count: 135
+Last run: 2026-04-06T15:55:41Z (Evolve Run #117)
+Run count: 136
 Phase: Phase 10: Chat + Multi-Agent Dashboard — P0 Critical UX Fixes
 Health: GREEN
 Error Budget: HEALTHY
-Tasks completed: 92 (#97 chat general handler + #98 chat-first UX)
-Current focus: #91 share_plan intent (QA failed — frontend handler missing)
-Next planned: #91 retry (frontend plan_shared handler + real-intent test)
+Tasks completed: 93 (#91 share_plan intent — frontend handler + real-intent test)
+Current focus: #92 E2E: share_plan Playwright scenarios
+Next planned: #93 reorder_days intent
 
 ## LTES Snapshot
 
@@ -29,6 +29,15 @@ Next planned: #91 retry (frontend plan_shared handler + real-intent test)
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #117 — 2026-04-06T15:55:41Z
+- **Task**: #91 - Chat: `share_plan` intent — generate shareable plan link via chat (retry)
+- **Result**: GREEN ✓ (QA pass)
+- **Tests**: 1510/1510 passed (+1 new: test_share_plan_real_intent_extraction_path), 5 skipped
+- **Files changed**: src/app/static/chat.js (+88/-0), tests/test_chat.py (+0)
+- **Builder note**: Frontend handler added — case 'plan_shared' dispatches to handlePlanShared(); renders copiable URL input + copy button in chat bubble AND in plan-panel dashboard (duplicate-removal). test_share_plan_real_intent_extraction_path mocks genai.Client at HTTP level only (not extract_intent) — Constraint #10 compliant.
+- **LTES**: L=37895ms T=1 commit E=0 test failures S=5 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✓ → reporter ✓
 
 ### Evolve Run #116 — 2026-04-06T14:00:00Z
 - **Task**: #91 - Chat: `share_plan` intent — generate shareable plan link via chat

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -7021,3 +7021,47 @@ class TestSharePlan:
         """'이 계획 공유해줘' should map to share_plan action in intent model."""
         intent = Intent(action="share_plan", raw_message="이 계획 공유해줘")
         assert intent.action == "share_plan"
+
+    def test_share_plan_real_intent_extraction_path(self):
+        """Integration: real extract_intent path (genai mocked at HTTP level, not at extract_intent level).
+
+        Constraint #10 compliance: extract_intent itself is NOT mocked.
+        We mock app.chat.genai.Client so the Gemini HTTP call returns a
+        controlled JSON intent, but the full extract_intent → _handle_share_plan
+        execution path runs for real.
+        """
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan_id = _seed_bare_plan(db)
+
+            # Build mock Gemini response that returns a share_plan intent JSON
+            share_intent = Intent(action="share_plan", raw_message="이 계획 공유해줘")
+            mock_response = MagicMock()
+            mock_response.text = share_intent.model_dump_json()
+            mock_client = MagicMock()
+            mock_client.models.generate_content.return_value = mock_response
+
+            with patch("app.chat.genai") as mock_genai:
+                mock_genai.Client.return_value = mock_client
+                # Use a non-empty api_key so extract_intent actually calls genai
+                svc = ChatService(api_key="fake-key-real-path", ttl_seconds=SESSION_TTL_SECONDS)
+                session = svc.create_session()
+                session.last_saved_plan_id = plan_id
+                events = _collect_events_with_db(svc, session.session_id, "이 계획 공유해줘", db)
+
+            # Verify Gemini was actually called (real extraction path ran)
+            assert mock_client.models.generate_content.called, \
+                "genai.Client.models.generate_content must be called — extract_intent must not be bypassed"
+
+            # Verify plan_shared event was emitted
+            shared_events = [e for e in events if e["type"] == "plan_shared"]
+            assert len(shared_events) == 1, f"Expected 1 plan_shared event, got {len(shared_events)}"
+            evt_data = shared_events[0]["data"]
+            assert "share_url" in evt_data
+            assert "share_token" in evt_data
+            assert evt_data["share_token"] is not None
+        finally:
+            db.close()
+            from app.database import Base
+            Base.metadata.drop_all(bind=engine)


### PR DESCRIPTION
## Evolve Run #117
- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: GREEN
- **Task**: #91 - Chat: share_plan intent — generate shareable plan link via chat (retry)
- **QA**: pass
- **Tests**: 1510/1510 passed (+1 new), 5 skipped

Closes #112

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #91 retry — frontend handler + real-intent test |
| 📐 Architect | ⏭️ | Skipped (Ready tasks ≥ 2) |
| 🔨 Builder | ✅ | chat.js: case 'plan_shared' → handlePlanShared(); copiable URL input + copy button in chat bubble AND plan-panel dashboard (duplicate-removal). test_share_plan_real_intent_extraction_path added (Constraint #10 compliant). |
| 🧪 QA | ✅ | All checks pass: done_criteria, integration_test_quality, lint, no_regressions, no_secrets_leaked. E2E skipped (pre-existing @playwright/test blocker). |
| 📝 Reporter | ✅ | This PR |

🤖 Auto-generated by Evolve Pipeline