### PR TITLE
test(wip): #92 E2E share_plan scenarios (#92)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -6,7 +6,14 @@
 
 ## In Progress
 
-_(없음)_
+- [ ] #92 - E2E: share_plan Playwright scenarios [test] ⚠️ QA FAIL (Run #118)
+  - ref: markdowns/feat-chat-dashboard.md
+  - depends: #91
+  - files: e2e/chat.spec.ts, **e2e/chat-integration.spec.ts** (missing coverage)
+  - done: "이 계획 공유해줘" → plan_shared SSE event fires → share URL rendered in chat; copy button visible; graceful error when no plan loaded; 2+ scenarios pass
+  - gh: #118
+  - **QA failure (Run #118)**: Builder added 2 scenarios to `e2e/chat.spec.ts` using `mockChatSession()` (route mock). Violates CLAUDE.md constraint #11 — route mock fully replaces SSE stream. `e2e/chat-integration.spec.ts` has zero share_plan coverage.
+  - **Fix**: Add 1–2 scenarios to `e2e/chat-integration.spec.ts` that POST '이 계획 공유해줘' to a live server and verify `plan_shared` in the real SSE stream. No `page.route()` mocking for SSE.
 
 ## Ready
   - **문제**: Plans 페이지가 빈 껍데기, "Create your first trip!" 링크만 존재. 사용자가 버튼을 조작하는 게 아니라 채팅만으로 모든 여행 관리가 되어야 함
@@ -16,12 +23,7 @@ _(없음)_
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
 
-- [ ] #92 - E2E: share_plan Playwright scenarios [test]
-  - ref: markdowns/feat-chat-dashboard.md
-  - depends: #91
-  - files: e2e/chat.spec.ts
-  - done: "이 계획 공유해줘" → plan_shared SSE event fires → share URL rendered in chat; copy button visible; graceful error when no plan loaded; 2+ scenarios pass
-  - gh: #118
+_(#92 → In Progress)_
 
 - [ ] #93 - Chat: `reorder_days` intent — swap/reorder days via chat [feature]
   - ref: markdowns/feat-chat-dashboard.md

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -1776,3 +1776,182 @@ test.describe("suggest_improvements + budget auto-refresh (Task #90)", () => {
     expect(width).toBeCloseTo(68.0, 0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// share_plan E2E scenarios (Task #92 / Issue #118)
+// ---------------------------------------------------------------------------
+
+test.describe("share_plan E2E scenarios (Task #92)", () => {
+  const SHARE_URL =
+    "https://travel-planner-ai.onrender.com/travel-plans/shared/abc123token";
+
+  /**
+   * Scenario A (Happy path):
+   * "이 계획 공유해줘" → plan_shared SSE fires → share URL rendered in chat bubble
+   * + copy button visible + .plan-share-card appears in dashboard.
+   */
+  test("share_plan: share URL rendered in chat bubble with copy button + dashboard card", async ({
+    page,
+  }) => {
+    await mockChatSession(page, [
+      {
+        type: "agent_status",
+        data: {
+          agent: "coordinator",
+          status: "thinking",
+          message: "요청 분석 중...",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "coordinator",
+          status: "done",
+          message: "share_plan 파악",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "secretary",
+          status: "working",
+          message: "공유 링크 생성 중...",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "secretary",
+          status: "done",
+          message: "공유 링크 생성 완료!",
+        },
+      },
+      {
+        type: "plan_shared",
+        data: {
+          plan_id: 7,
+          share_token: "abc123token",
+          share_url: SHARE_URL,
+        },
+      },
+      {
+        type: "chat_chunk",
+        data: { text: `공유 링크가 생성되었습니다: ${SHARE_URL}` },
+      },
+      { type: "chat_done", data: {} },
+    ]);
+
+    await goToChat(page);
+    await page.fill("#chat-input", "이 계획 공유해줘");
+    await page.click('button:has-text("전송")');
+
+    // Secretary must reach done state
+    await expect(page.locator('[data-agent="secretary"]')).toHaveClass(
+      /agent-done/,
+      { timeout: 10_000 }
+    );
+
+    // Chat bubble: URL input with aria-label "공유 링크" must show the share URL
+    const urlInput = page.locator('input[aria-label="공유 링크"]');
+    await expect(urlInput).toBeVisible({ timeout: 10_000 });
+    await expect(urlInput).toHaveValue(SHARE_URL);
+
+    // Chat bubble: copy button must be visible
+    // The copy button is a sibling of the URL input inside the chat bubble
+    const chatBubble = page.locator(".chat-bubble.chat-ai", {
+      has: urlInput,
+    });
+    await expect(chatBubble).toBeVisible();
+    const copyBtn = chatBubble.locator("button", { hasText: "복사" });
+    await expect(copyBtn).toBeVisible();
+
+    // Dashboard: .plan-share-card must appear in #plan-panel
+    await expect(page.locator(".plan-share-card")).toBeVisible();
+
+    // Dashboard share card contains a URL input with the share URL
+    const panelInput = page.locator(
+      '.plan-share-card input[aria-label="공유 링크 (대시보드)"]'
+    );
+    await expect(panelInput).toBeVisible();
+    await expect(panelInput).toHaveValue(SHARE_URL);
+
+    // Dashboard share card copy button must be visible
+    const panelCopyBtn = page.locator("#share-copy-btn-panel");
+    await expect(panelCopyBtn).toBeVisible();
+    await expect(panelCopyBtn).toContainText("복사");
+  });
+
+  /**
+   * Scenario B (Error — no plan loaded):
+   * User asks to share but no plan is saved → secretary hits error state →
+   * error message appears in chat → no .plan-share-card in dashboard.
+   */
+  test("share_plan: graceful error when no plan is loaded", async ({
+    page,
+  }) => {
+    await mockChatSession(page, [
+      {
+        type: "agent_status",
+        data: {
+          agent: "coordinator",
+          status: "thinking",
+          message: "요청 분석 중...",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "coordinator",
+          status: "done",
+          message: "share_plan 파악",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "secretary",
+          status: "working",
+          message: "공유 링크 생성 중...",
+        },
+      },
+      // No plan saved → secretary hits error, no plan_shared event emitted
+      {
+        type: "agent_status",
+        data: {
+          agent: "secretary",
+          status: "error",
+          message: "저장된 계획이 없습니다",
+        },
+      },
+      {
+        type: "chat_chunk",
+        data: {
+          text: "공유할 여행 계획이 없습니다. 먼저 계획을 저장해주세요.",
+        },
+      },
+      { type: "chat_done", data: {} },
+    ]);
+
+    await goToChat(page);
+    await page.fill("#chat-input", "이 계획 공유해줘");
+    await page.click('button:has-text("전송")');
+
+    // Secretary must reach error state
+    await expect(page.locator('[data-agent="secretary"]')).toHaveClass(
+      /agent-error/,
+      { timeout: 10_000 }
+    );
+
+    // Error message must appear in chat
+    await expect(page.locator("#chat-messages")).toContainText(
+      "공유할 여행 계획이 없습니다",
+      { timeout: 10_000 }
+    );
+
+    // No plan-share-card must exist in the dashboard (plan_shared was never fired)
+    await expect(page.locator(".plan-share-card")).not.toBeVisible();
+
+    // No URL input for share link in chat
+    await expect(page.locator('input[aria-label="공유 링크"]')).not.toBeVisible();
+  });
+});

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,13 +1,13 @@
 {
-  "last_updated": "2026-04-06T16:00:00Z",
+  "last_updated": "2026-04-06T17:00:00Z",
   "summary": {
-    "total_runs": 137,
-    "total_commits": 125,
+    "total_runs": 138,
+    "total_commits": 126,
     "total_tests": 1510,
     "tasks_completed": 93,
     "tasks_remaining": 5,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
-    "health": "GREEN"
+    "health": "YELLOW"
   },
   "daily_trend": [
     {
@@ -57,12 +57,12 @@
     },
     {
       "date": "2026-04-06",
-      "runs": 7,
+      "runs": 8,
       "tasks_completed": 2,
       "tests_passed": 1510,
       "tests_failed": 0,
-      "commits": 22,
-      "health": "GREEN"
+      "commits": 23,
+      "health": "YELLOW"
     }
   ],
   "ltes_7d_avg": {
@@ -78,10 +78,10 @@
     "health": "GREEN"
   },
   "last_evolve": {
-    "timestamp": "2026-04-06T14:00:00Z",
-    "run_id": "2026-04-06-1400",
-    "task": "#91 - Chat: share_plan intent — generate shareable plan link via chat",
-    "tests_passed": 1509,
+    "timestamp": "2026-04-06T17:00:00Z",
+    "run_id": "2026-04-06-1700",
+    "task": "#92 - E2E: share_plan Playwright scenarios",
+    "tests_passed": 1510,
     "tests_failed": 0,
     "health": "YELLOW",
     "qa_verdict": "fail"

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,11 +7,11 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 137,
+    "total_runs": 138,
     "successful_runs": 131,
-    "failed_runs": 1,
-    "success_rate": 0.956,
-    "budget_remaining": 0.95,
+    "failed_runs": 2,
+    "success_rate": 0.949,
+    "budget_remaining": 0.94,
     "status": "HEALTHY"
   },
   "policy": {
@@ -651,7 +651,7 @@
       "tests_total": 1241
     }
   ],
-  "consecutive_qa_failures": 0,
+  "consecutive_qa_failures": 1,
   "history_tail": {
     "run_id": "monitor-2026-04-06-1600",
     "task": "monitor",

--- a/observability/logs/2026-04-06/run-17-00.json
+++ b/observability/logs/2026-04-06/run-17-00.json
@@ -1,0 +1,76 @@
+{
+  "trace": {
+    "run_id": "2026-04-06-1700",
+    "timestamp": "2026-04-06T17:00:00Z",
+    "phase": "Phase 10: Chat + Multi-Agent Dashboard — P0 Critical UX Fixes",
+    "health": "YELLOW",
+    "task": "#92 - E2E: share_plan Playwright scenarios",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "fail",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #92: E2E share_plan Playwright scenarios. Health GREEN, 1510/1515 tests passing."
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "backlog_ready_count=5 >= 2, no architect run needed"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "Added 2 Playwright E2E scenarios to e2e/chat.spec.ts (+148 lines). Scenario A: share_plan happy path. Scenario B: graceful error when no plan loaded."
+    },
+    {
+      "agent": "qa",
+      "status": "fail",
+      "detail": "all_tests_pass: pass | new_tests_exist: pass | lint_clean: pass | done_criteria_met: pass | no_regressions: pass | integration_test_quality: FAIL (route mock replaces SSE — CLAUDE.md constraint #11 violation) | e2e_integration: FAIL (no real-server scenarios in chat-integration.spec.ts)"
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Writing logs, updating state files, creating PR"
+    }
+  ],
+  "ltes": {
+    "latency": {
+      "total_duration_ms": 0
+    },
+    "traffic": {
+      "commits": 1,
+      "lines_added": 148,
+      "lines_removed": 0,
+      "files_changed": 1
+    },
+    "errors": {
+      "test_failures": 0,
+      "fix_attempts": 0,
+      "qa_checks_failed": 2,
+      "qa_checks_passed": 6
+    },
+    "saturation": {
+      "backlog_remaining": 5
+    }
+  },
+  "qa_detail": {
+    "verdict": "fail",
+    "checks": {
+      "all_tests_pass": "pass (1510/1515, 5 skipped)",
+      "new_tests_exist": "pass (+148 lines, 2 new Playwright scenarios)",
+      "lint_clean": "pass",
+      "done_criteria_met": "pass",
+      "no_regressions": "pass",
+      "integration_test_quality": "FAIL — mockChatSession() uses page.route fulfill to replace SSE stream (constraint #11 violation)",
+      "e2e_integration": "FAIL — chat-integration.spec.ts has zero share_plan coverage; no real-server scenarios added"
+    },
+    "fix_recommendation": "Add 1-2 scenarios to e2e/chat-integration.spec.ts that run against a live server without route mocking. POST /chat/sessions/{id}/messages with '이 계획 공유해줘', verify plan_shared SSE event in real stream."
+  }
+}

--- a/status.md
+++ b/status.md
@@ -1,19 +1,19 @@
 # Status
 
-Last run: 2026-04-06T16:00:00Z (Monitor Run #129)
-Run count: 137
+Last run: 2026-04-06T17:00:00Z (Evolve Run #118)
+Run count: 138
 Phase: Phase 10: Chat + Multi-Agent Dashboard — P0 Critical UX Fixes
-Health: GREEN
+Health: YELLOW
 Error Budget: HEALTHY
 Tasks completed: 93 (#91 share_plan intent — frontend handler + real-intent test)
-Current focus: #92 E2E: share_plan Playwright scenarios
-Next planned: #93 reorder_days intent
+Current focus: #92 E2E: share_plan Playwright scenarios (QA fail — retrying)
+Next planned: #92 retry (real-server integration test in chat-integration.spec.ts)
 
 ## LTES Snapshot
 
-- Latency: 36170ms (pytest 26.75s + overhead)
-- Traffic: 27 commits/24h
-- Errors: 0 test failures (1510/1510 pass), 5 skipped, error_rate=0.0%
+- Latency: N/A (QA fail — no runtime metric)
+- Traffic: 28 commits/24h
+- Errors: 0 unit test failures (1510/1515 pass, 5 skipped), QA checks: 2 fail (integration_test_quality, e2e_integration)
 - Saturation: 5 tasks ready
 
 ## Phase Transition
@@ -29,6 +29,18 @@ Next planned: #93 reorder_days intent
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #118 — 2026-04-06T17:00:00Z
+- **Task**: #92 - E2E: share_plan Playwright scenarios
+- **Result**: YELLOW ✗ (QA fail)
+- **Tests**: 1510/1515 passed (5 skipped), 0 unit test failures
+- **QA failures**:
+  - `integration_test_quality` FAIL — both new scenarios use `mockChatSession()` which calls `page.route('**/chat/sessions/*/messages', route.fulfill(...))`, fully replacing the SSE stream. CLAUDE.md constraint #11 violation.
+  - `e2e_integration` FAIL — `e2e/chat-integration.spec.ts` (real server, no route mock) has zero share_plan coverage; new tests only added to route-mocked spec.
+- **Files changed**: e2e/chat.spec.ts (+148/-0)
+- **Fix needed**: Add 1–2 scenarios to `e2e/chat-integration.spec.ts` against a live server — POST '이 계획 공유해줘' to real endpoint, verify `plan_shared` SSE event in real stream. No route mocking.
+- **LTES**: L=N/A T=1 commit E=2 QA checks fail S=5 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✗ → reporter ✓
 
 ### Monitor Run #129 — 2026-04-06T16:00:00Z
 - **Task**: monitor


### PR DESCRIPTION
## Evolve Run #138

- **Phase**: Phase 10: Chat + Multi-Agent Dashboard — P0 Critical UX Fixes
- **Health**: YELLOW
- **Task**: #92 - E2E: share_plan Playwright scenarios
- **QA**: ❌ fail

### Agent Activity

| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #92; health GREEN, 1510/1515 tests passing |
| 📐 Architect | ⏭️ | Skipped — backlog_ready_count=5 ≥ 2 |
| 🔨 Builder | ✅ | e2e/chat.spec.ts +148 lines — 2 new Playwright scenarios (share_plan happy path + graceful error) |
| 🧪 QA | ❌ | 6/8 checks pass; 2 fail: `integration_test_quality` + `e2e_integration` |
| 📝 Reporter | ✅ | This PR |

### QA Failures

| Check | Result | Detail |
|-------|--------|--------|
| all_tests_pass | ✅ | 1510/1515 passed, 5 skipped |
| new_tests_exist | ✅ | +148 lines, 2 new Playwright scenarios |
| lint_clean | ✅ | ruff check: all passed |
| done_criteria_met | ✅ | 2+ scenarios cover spec |
| no_regressions | ✅ | Same baseline count |
| integration_test_quality | ❌ | Both scenarios use `mockChatSession()` → `page.route` fulfills SSE — violates CLAUDE.md constraint #11 |
| e2e_integration | ❌ | `e2e/chat-integration.spec.ts` has zero share_plan coverage (requires real server, no route mock) |

### Fix Required

Add 1–2 scenarios to `e2e/chat-integration.spec.ts` that:
1. POST `'이 계획 공유해줘'` to a live server
2. Verify `plan_shared` SSE event in the **real** stream (no `page.route()` SSE replacement)

🤖 Auto-generated by Evolve Pipeline