### PR TITLE
test(wip): #92 E2E share_plan scenarios — Scenario A assertion fix needed

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -6,7 +6,13 @@
 
 ## In Progress
 
-_(없음)_
+- [ ] #92 - E2E: share_plan Playwright scenarios [test]
+  - ref: markdowns/feat-chat-dashboard.md
+  - depends: #91
+  - files: e2e/chat.spec.ts
+  - done: "이 계획 공유해줘" → plan_shared SSE event fires → share URL rendered in chat; copy button visible; graceful error when no plan loaded; 2+ scenarios pass
+  - gh: #118
+  - ❌ QA fail (Run #118, 2026-04-06): Scenario A fails at line 1567 — `toContainText` used on `.plan-share-card` but share URL is in `<input value='...'>`. Fix: `await expect(page.locator('.plan-share-card input[aria-label="공유 링크 (대시보드)"]')).toHaveValue(SHARE_URL)`
 
 ## Ready
   - **문제**: Plans 페이지가 빈 껍데기, "Create your first trip!" 링크만 존재. 사용자가 버튼을 조작하는 게 아니라 채팅만으로 모든 여행 관리가 되어야 함
@@ -15,13 +21,6 @@ _(없음)_
   - done: 사이트 접속 시 바로 채팅 인터페이스; 빈 상태에서 가이드/예시 표시; Plans 탭은 저장된 계획 목록만; 시각적으로 현대적; 기존 E2E 깨지지 않음
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
-
-- [ ] #92 - E2E: share_plan Playwright scenarios [test]
-  - ref: markdowns/feat-chat-dashboard.md
-  - depends: #91
-  - files: e2e/chat.spec.ts
-  - done: "이 계획 공유해줘" → plan_shared SSE event fires → share URL rendered in chat; copy button visible; graceful error when no plan loaded; 2+ scenarios pass
-  - gh: #118
 
 - [ ] #93 - Chat: `reorder_days` intent — swap/reorder days via chat [feature]
   - ref: markdowns/feat-chat-dashboard.md

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -1474,6 +1474,173 @@ test.describe("SSE reconnect + session state restore", () => {
 });
 
 // ---------------------------------------------------------------------------
+// share_plan E2E scenarios (Task #92 / Issue #118)
+// ---------------------------------------------------------------------------
+
+test.describe("share_plan E2E scenarios (Task #92)", () => {
+  /**
+   * Scenario A (happy path):
+   *   User says "이 계획 공유해줘"
+   *   → plan_shared SSE event fires
+   *   → share URL rendered in chat bubble with a copy button
+   *   → .plan-share-card appears in the plan panel
+   *   → secretary reaches agent-done state
+   */
+  test("share_plan: share URL rendered in chat + copy button visible", async ({
+    page,
+  }) => {
+    const SHARE_URL = "http://localhost:8000/travel-plans/shared/abc123tok";
+
+    await mockChatSession(page, [
+      {
+        type: "agent_status",
+        data: {
+          agent: "coordinator",
+          status: "thinking",
+          message: "요청 분석 중...",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "coordinator",
+          status: "done",
+          message: "share_plan 파악",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "secretary",
+          status: "working",
+          message: "공유 링크 생성 중...",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "secretary",
+          status: "done",
+          message: "공유 링크 생성 완료!",
+        },
+      },
+      {
+        type: "plan_shared",
+        data: {
+          plan_id: 7,
+          share_token: "abc123tok",
+          share_url: SHARE_URL,
+        },
+      },
+      {
+        type: "chat_chunk",
+        data: { text: `공유 링크가 생성되었습니다: ${SHARE_URL}` },
+      },
+      { type: "chat_done", data: {} },
+    ]);
+
+    await goToChat(page);
+    await page.fill("#chat-input", "이 계획 공유해줘");
+    await page.click('button:has-text("전송")');
+
+    // Secretary must reach done state
+    await expect(page.locator('[data-agent="secretary"]')).toHaveClass(
+      /agent-done/,
+      { timeout: 10_000 }
+    );
+
+    // A chat bubble must appear with the share URL input
+    const urlInput = page.locator('#chat-messages input[aria-label="공유 링크"]');
+    await expect(urlInput).toBeVisible({ timeout: 10_000 });
+    await expect(urlInput).toHaveValue(SHARE_URL);
+
+    // Copy button must be visible in the chat bubble
+    const copyBtnChat = page.locator('#chat-messages button:has-text("복사")');
+    await expect(copyBtnChat).toBeVisible();
+
+    // .plan-share-card must appear in the plan panel
+    await expect(page.locator(".plan-share-card")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // The share card must contain the URL
+    await expect(page.locator(".plan-share-card")).toContainText("abc123tok");
+
+    // Copy button in the dashboard panel must also be visible
+    const panelCopyBtn = page.locator("#share-copy-btn-panel");
+    await expect(panelCopyBtn).toBeVisible();
+  });
+
+  /**
+   * Scenario B (no plan loaded — graceful error):
+   *   User says "이 계획 공유해줘" but no plan has been saved.
+   *   → secretary reaches agent-error state
+   *   → chat shows an error message about no plan to share
+   *   → no .plan-share-card rendered
+   */
+  test("share_plan: graceful error when no plan loaded", async ({ page }) => {
+    await mockChatSession(page, [
+      {
+        type: "agent_status",
+        data: {
+          agent: "coordinator",
+          status: "thinking",
+          message: "요청 분석 중...",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "coordinator",
+          status: "done",
+          message: "share_plan 파악",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "secretary",
+          status: "working",
+          message: "공유 링크 생성 중...",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "secretary",
+          status: "error",
+          message: "저장된 계획이 없습니다",
+        },
+      },
+      {
+        type: "chat_chunk",
+        data: { text: "공유할 여행 계획이 없습니다. 먼저 계획을 저장해주세요." },
+      },
+      { type: "chat_done", data: {} },
+    ]);
+
+    await goToChat(page);
+    await page.fill("#chat-input", "이 계획 공유해줘");
+    await page.click('button:has-text("전송")');
+
+    // Secretary must reach error state
+    await expect(page.locator('[data-agent="secretary"]')).toHaveClass(
+      /agent-error/,
+      { timeout: 10_000 }
+    );
+
+    // Error message must appear in chat
+    await expect(page.locator("#chat-messages")).toContainText(
+      "공유할 여행 계획이 없습니다",
+      { timeout: 10_000 }
+    );
+
+    // No share card should be rendered in the plan panel
+    await expect(page.locator(".plan-share-card")).not.toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // suggest_improvements + budget auto-refresh (Task #90 / Issue #111)
 // ---------------------------------------------------------------------------
 

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,13 +1,13 @@
 {
-  "last_updated": "2026-04-06T17:32:00Z",
+  "last_updated": "2026-04-06T18:00:00Z",
   "summary": {
-    "total_runs": 138,
-    "total_commits": 125,
+    "total_runs": 139,
+    "total_commits": 126,
     "total_tests": 1510,
     "tasks_completed": 93,
     "tasks_remaining": 5,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
-    "health": "GREEN"
+    "health": "YELLOW"
   },
   "daily_trend": [
     {
@@ -57,12 +57,12 @@
     },
     {
       "date": "2026-04-06",
-      "runs": 8,
+      "runs": 9,
       "tasks_completed": 2,
       "tests_passed": 1510,
-      "tests_failed": 0,
-      "commits": 25,
-      "health": "GREEN"
+      "tests_failed": 1,
+      "commits": 26,
+      "health": "YELLOW"
     }
   ],
   "ltes_7d_avg": {
@@ -78,11 +78,11 @@
     "health": "GREEN"
   },
   "last_evolve": {
-    "timestamp": "2026-04-06T14:00:00Z",
-    "run_id": "2026-04-06-1400",
-    "task": "#91 - Chat: share_plan intent — generate shareable plan link via chat",
-    "tests_passed": 1509,
-    "tests_failed": 0,
+    "timestamp": "2026-04-06T18:00:00Z",
+    "run_id": "2026-04-06-1800",
+    "task": "#92 - E2E: share_plan Playwright scenarios",
+    "tests_passed": 1510,
+    "tests_failed": 1,
     "health": "YELLOW",
     "qa_verdict": "fail"
   }

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,10 +7,10 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 138,
+    "total_runs": 139,
     "successful_runs": 132,
-    "failed_runs": 1,
-    "success_rate": 0.957,
+    "failed_runs": 2,
+    "success_rate": 0.950,
     "budget_remaining": 0.95,
     "status": "HEALTHY"
   },
@@ -651,16 +651,16 @@
       "tests_total": 1241
     }
   ],
-  "consecutive_qa_failures": 0,
+  "consecutive_qa_failures": 1,
   "history_tail": {
-    "run_id": "monitor-2026-04-06-1732",
-    "task": "monitor",
-    "result": "success",
+    "run_id": "2026-04-06-1800",
+    "task": "#92 - E2E: share_plan Playwright scenarios",
+    "result": "fail",
     "tests_passed": 1510,
     "tests_total": 1510
   },
   "history_tail_prev": {
-    "run_id": "monitor-2026-04-06-1600",
+    "run_id": "monitor-2026-04-06-1732",
     "task": "monitor",
     "result": "success",
     "tests_passed": 1510,

--- a/observability/logs/2026-04-06/run-18-00.json
+++ b/observability/logs/2026-04-06/run-18-00.json
@@ -1,0 +1,78 @@
+{
+  "trace": {
+    "run_id": "2026-04-06-1800",
+    "timestamp": "2026-04-06T18:00:00Z",
+    "phase": "Phase 10: Chat + Multi-Agent Dashboard",
+    "health": "YELLOW",
+    "task": "#92 - E2E: share_plan Playwright scenarios",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "fail",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #92 (E2E: share_plan Playwright scenarios). No fix needed, no architect needed. Health GREEN at start."
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "backlog_ready_count=5 >= 2, architect skipped"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "Added 2 E2E Playwright scenarios in e2e/chat.spec.ts (+162 lines). Scenario A: happy path (plan_shared SSE). Scenario B: graceful error (no plan loaded)."
+    },
+    {
+      "agent": "qa",
+      "status": "fail",
+      "detail": "1510/1510 pytest pass. E2E Scenario B passes. Scenario A fails at line 1567: toContainText used on .plan-share-card instead of toHaveValue on input element. done_criteria_met: FAIL (only 1/2 E2E scenarios pass)."
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Writing logs, updating status/backlog/budget, creating PR with evolve-needs-review label."
+    }
+  ],
+  "ltes": {
+    "latency": {
+      "total_duration_ms": 50000
+    },
+    "traffic": {
+      "commits": 1,
+      "lines_added": 162,
+      "lines_removed": 0,
+      "files_changed": 1
+    },
+    "errors": {
+      "test_failures": 1,
+      "fix_attempts": 0
+    },
+    "saturation": {
+      "backlog_remaining": 5
+    }
+  },
+  "qa_checks": {
+    "all_tests_pass": "pass",
+    "new_tests_exist": "pass",
+    "lint_clean": "pass",
+    "done_criteria_met": "fail",
+    "no_regressions": "pass",
+    "integration_test_quality": "pass",
+    "e2e_integration": "fail",
+    "no_secrets_leaked": "pass"
+  },
+  "issues": [
+    {
+      "severity": "fail",
+      "location": "e2e/chat.spec.ts:1567",
+      "description": "Scenario A assertion incorrect: toContainText used on .plan-share-card but share URL is in an input value attribute. Fix: use toHaveValue on .plan-share-card input[aria-label='공유 링크 (대시보드)']"
+    }
+  ]
+}

--- a/status.md
+++ b/status.md
@@ -1,19 +1,19 @@
 # Status
 
-Last run: 2026-04-06T17:32:00Z (Monitor Run #130)
-Run count: 138
+Last run: 2026-04-06T18:00:00Z (Evolve Run #118)
+Run count: 139
 Phase: Phase 10: Chat + Multi-Agent Dashboard — P0 Critical UX Fixes
-Health: GREEN
+Health: YELLOW
 Error Budget: HEALTHY
 Tasks completed: 93 (#91 share_plan intent — frontend handler + real-intent test)
-Current focus: #92 E2E: share_plan Playwright scenarios
-Next planned: #93 reorder_days intent
+Current focus: #92 E2E: share_plan Playwright scenarios (QA fail — retry needed)
+Next planned: #92 retry → #93 reorder_days intent
 
 ## LTES Snapshot
 
-- Latency: 50000ms (pytest 25.76s + overhead)
-- Traffic: 25 commits/24h
-- Errors: 0 test failures (1510/1510 pass), 5 skipped, error_rate=0.0%
+- Latency: 50000ms (pytest ~25s + overhead)
+- Traffic: 26 commits/24h
+- Errors: 1 E2E test failure (Scenario A assertion wrong), pytest 1510/1510 pass, error_rate=0.07%
 - Saturation: 5 tasks ready
 
 ## Phase Transition
@@ -29,6 +29,18 @@ Next planned: #93 reorder_days intent
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #118 — 2026-04-06T18:00:00Z
+- **Task**: #92 - E2E: share_plan Playwright scenarios [test]
+- **Result**: YELLOW ✗ (QA fail)
+- **Tests**: 1510/1510 pytest passed (5 skipped), lint clean
+- **QA failures**:
+  - `done_criteria_met` FAIL — only 1/2 E2E scenarios pass (Scenario B passes, Scenario A fails)
+  - `e2e_integration` FAIL — e2e/chat.spec.ts:1567: `toContainText` used on `.plan-share-card` but share URL lives in `<input value='...'>`. Fix: use `toHaveValue` on `.plan-share-card input[aria-label='공유 링크 (대시보드)']`
+- **Files changed**: e2e/chat.spec.ts (+162/-0)
+- **Builder note**: 2 E2E scenarios added. Scenario B (graceful error, no plan loaded) passes. Scenario A (happy path) has wrong assertion type for input value.
+- **LTES**: L=50000ms T=1 commit E=1 E2E failure S=5 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✗ → reporter ✓
 
 ### Monitor Run #130 — 2026-04-06T17:32:00Z
 - **Task**: monitor


### PR DESCRIPTION
## Evolve Run #118

- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: YELLOW
- **Task**: #92 - E2E: share_plan Playwright scenarios [test]
- **QA**: ❌ fail
- **Tests**: 1510/1510 pytest passed, 5 skipped

### Agent Activity

| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #92; health GREEN; no fix/architect needed |
| 📐 Architect | ⏭️ | Skipped (backlog_ready_count=5 ≥ 2) |
| 🔨 Builder | ✅ | e2e/chat.spec.ts +162 lines — 2 E2E scenarios added (Scenario A: happy path, Scenario B: graceful error) |
| 🧪 QA | ❌ | Scenario B PASS; Scenario A FAIL at line 1567 — wrong assertion type for input value |
| 📝 Reporter | ✅ | This PR |

### QA Failure Detail

**Failing check**: `e2e_integration` + `done_criteria_met`

**Location**: `e2e/chat.spec.ts:1567`

**Root cause**: Assertion uses `toContainText` on `.plan-share-card`, but the share URL is stored as an `<input readonly value='...'>` element. `toContainText` checks visible text content, not input values.

**Fix needed**:
```ts
// WRONG (current):
await expect(page.locator('.plan-share-card')).toContainText('abc123tok');

// CORRECT:
await expect(page.locator('.plan-share-card input[aria-label="공유 링크 (대시보드)"]')).toHaveValue(SHARE_URL);
```

All other Scenario A assertions (agent-done state, URL input in chat, copy button in chat, `.plan-share-card` visible, `#share-copy-btn-panel` visible) would pass. Only this one assertion needs fixing.

---

🤖 Auto-generated by Evolve Pipeline