### PR TITLE
feat(wip): #93 reorder_days E2E scenarios (QA fail — backend missing)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -6,18 +6,21 @@
 
 ## In Progress
 
-_(없음)_
+- [ ] #93 - Chat: `reorder_days` intent — swap/reorder days via chat [feature]
+  - ref: markdowns/feat-chat-dashboard.md
+  - depends: #91
+  - files: src/app/chat.py, tests/test_chat_reorder_days.py, e2e/chat.spec.ts
+  - done: "1일차랑 3일차 바꿔줘" → places swapped in DB → day_update SSE for both days; chat reply confirms; error on out-of-range day; Python integration tests pass; 2+ real-server Playwright scenarios pass
+  - gh: #118
+  - ❌ QA FAILED (Run #120 — 2026-04-06T20:00:00Z):
+    - Backend `reorder_days` handler NOT implemented in `src/app/chat.py` (constraint #done_criteria)
+    - No Python integration tests added (CLAUDE.md constraint #9)
+    - Route-mock E2E rejected: constraint #11 disqualifies mockChatSession-based scenarios
+  - Fix: implement `_handle_reorder_days` in chat.py + add `tests/test_chat_reorder_days.py` + real-server Playwright scenario
 
 ## Ready
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
-
-- [ ] #93 - Chat: `reorder_days` intent — swap/reorder days via chat [feature]
-  - ref: markdowns/feat-chat-dashboard.md
-  - depends: #91
-  - files: e2e/chat.spec.ts
-  - done: "이 계획 공유해줘" → plan_shared SSE event fires → share URL rendered in chat; copy button visible; graceful error when no plan loaded; 2+ scenarios pass
-  - gh: #118
 
 - [ ] #93 - Chat: `reorder_days` intent — swap/reorder days via chat [feature]
   - ref: markdowns/feat-chat-dashboard.md

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -1969,3 +1969,220 @@ test.describe("suggest_improvements + budget auto-refresh (Task #90)", () => {
     expect(width).toBeCloseTo(68.0, 0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// reorder_days E2E scenarios (Task #93 / Issue #118)
+// ---------------------------------------------------------------------------
+
+test.describe("reorder_days intent E2E (Task #93)", () => {
+  /**
+   * Scenario A (happy path):
+   * "1일차랑 3일차 바꿔줘" → coordinator done → planner working →
+   * two day_update SSE events (Day 1 ↔ Day 3 content swapped) →
+   * planner done → chat confirms swap.
+   *
+   * Done criteria:
+   *   - planner reaches agent-done state
+   *   - day card #day-2026-05-01 shows Day 3's place content (신주쿠 교엔)
+   *   - day card #day-2026-05-03 shows Day 1's place content (센소지)
+   *   - chat reply contains confirmation of the swap
+   */
+  test("reorder_days: swap day 1 and day 3 updates both day cards", async ({
+    page,
+  }) => {
+    await mockChatSession(page, [
+      {
+        type: "agent_status",
+        data: {
+          agent: "coordinator",
+          status: "thinking",
+          message: "요청 분석 중...",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "coordinator",
+          status: "done",
+          message: "reorder_days 파악",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "planner",
+          status: "working",
+          message: "Day 1 ↔ Day 3 순서 변경 중...",
+        },
+      },
+      // day_update for 2026-05-01 — now receives Day 3's original content
+      {
+        type: "day_update",
+        data: {
+          day: 1,
+          date: "2026-05-01",
+          theme: "신주쿠",
+          places: [
+            {
+              name: "신주쿠 교엔",
+              category: "자연",
+              address: "도쿄 신주쿠",
+              estimated_cost: 500,
+              ai_reason: "대형 정원",
+              order: 1,
+            },
+          ],
+          notes: "",
+        },
+      },
+      // day_update for 2026-05-03 — now receives Day 1's original content
+      {
+        type: "day_update",
+        data: {
+          day: 3,
+          date: "2026-05-03",
+          theme: "아사쿠사",
+          places: [
+            {
+              name: "센소지",
+              category: "문화",
+              address: "도쿄 아사쿠사",
+              estimated_cost: 0,
+              ai_reason: "유명 사원",
+              order: 1,
+            },
+          ],
+          notes: "",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "planner",
+          status: "done",
+          message: "Day 1 ↔ Day 3 순서 변경 완료!",
+        },
+      },
+      {
+        type: "chat_chunk",
+        data: { text: "Day 1과 Day 3의 일정을 교체했습니다." },
+      },
+      { type: "chat_done", data: {} },
+    ]);
+
+    await goToChat(page);
+    await page.fill("#chat-input", "1일차랑 3일차 바꿔줘");
+    await page.click('button:has-text("전송")');
+
+    // Planner must reach done state
+    await expect(page.locator('[data-agent="planner"]')).toHaveClass(
+      /agent-done/,
+      { timeout: 10_000 }
+    );
+
+    // Planner agent message must confirm the swap
+    await expect(
+      page.locator('[data-agent="planner"] .agent-message')
+    ).toContainText("순서 변경 완료");
+
+    // Day card for 2026-05-01 must be visible and contain Day 3's content
+    await expect(
+      page.locator("#day-2026-05-01")
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("#day-2026-05-01")).toContainText("신주쿠 교엔");
+
+    // Day card for 2026-05-03 must be visible and contain Day 1's content
+    await expect(
+      page.locator("#day-2026-05-03")
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("#day-2026-05-03")).toContainText("센소지");
+
+    // Chat reply must confirm the swap
+    await expect(page.locator("#chat-messages")).toContainText(
+      "Day 1과 Day 3의 일정을 교체했습니다.",
+      { timeout: 10_000 }
+    );
+  });
+
+  /**
+   * Scenario B (error — out-of-range day):
+   * "10일차랑 2일차 바꿔줘" when the plan has only 3 days →
+   * planner reaches agent-error state + chat shows an error/guidance message.
+   *
+   * Done criteria:
+   *   - planner card carries agent-error class
+   *   - planner agent message contains the out-of-range error description
+   *   - chat contains guidance asking for a valid day number
+   */
+  test("reorder_days error: out-of-range day → planner error + guidance message", async ({
+    page,
+  }) => {
+    await mockChatSession(page, [
+      {
+        type: "agent_status",
+        data: {
+          agent: "coordinator",
+          status: "thinking",
+          message: "요청 분석 중...",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "coordinator",
+          status: "done",
+          message: "reorder_days 파악",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "planner",
+          status: "working",
+          message: "Day 10 ↔ Day 2 순서 변경 중...",
+        },
+      },
+      {
+        type: "agent_status",
+        data: {
+          agent: "planner",
+          status: "error",
+          message: "범위를 벗어난 날짜 번호입니다",
+        },
+      },
+      {
+        type: "chat_chunk",
+        data: {
+          text: "Day 10은 계획 범위를 벗어납니다. 유효한 날짜 번호를 입력해주세요.",
+        },
+      },
+      { type: "chat_done", data: {} },
+    ]);
+
+    await goToChat(page);
+    await page.fill("#chat-input", "10일차랑 2일차 바꿔줘");
+    await page.click('button:has-text("전송")');
+
+    // Planner must reach error state
+    await expect(page.locator('[data-agent="planner"]')).toHaveClass(
+      /agent-error/,
+      { timeout: 10_000 }
+    );
+
+    // Planner agent message must describe the error
+    await expect(
+      page.locator('[data-agent="planner"] .agent-message')
+    ).toContainText("범위를 벗어난");
+
+    // Chat must display the guidance message
+    await expect(page.locator("#chat-messages")).toContainText(
+      "유효한 날짜 번호를 입력해주세요",
+      { timeout: 10_000 }
+    );
+
+    // No day_update events fired — #day-2026-05-10 must not be created
+    await expect(
+      page.locator('[id^="day-"]')
+    ).toHaveCount(0);
+  });
+});

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,13 +1,13 @@
 {
-  "last_updated": "2026-04-06T19:00:00Z",
+  "last_updated": "2026-04-06T20:00:00Z",
   "summary": {
-    "total_runs": 141,
-    "total_commits": 128,
+    "total_runs": 142,
+    "total_commits": 129,
     "total_tests": 1522,
     "tasks_completed": 95,
-    "tasks_remaining": 5,
+    "tasks_remaining": 4,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
-    "health": "GREEN"
+    "health": "YELLOW"
   },
   "daily_trend": [
     {
@@ -57,12 +57,12 @@
     },
     {
       "date": "2026-04-06",
-      "runs": 11,
+      "runs": 12,
       "tasks_completed": 4,
       "tests_passed": 1517,
-      "tests_failed": 0,
-      "commits": 28,
-      "health": "GREEN"
+      "tests_failed": 3,
+      "commits": 29,
+      "health": "YELLOW"
     }
   ],
   "ltes_7d_avg": {
@@ -78,12 +78,12 @@
     "health": "GREEN"
   },
   "last_evolve": {
-    "timestamp": "2026-04-06T19:00:00Z",
-    "run_id": "2026-04-06-1900",
-    "task": "#99 - Frontend: chat-first landing + modern UX redesign",
+    "timestamp": "2026-04-06T20:00:00Z",
+    "run_id": "2026-04-06-2000",
+    "task": "#93 - Chat: reorder_days intent (E2E scenarios)",
     "tests_passed": 1517,
-    "tests_failed": 0,
-    "health": "GREEN",
-    "qa_verdict": "pass"
+    "tests_failed": 3,
+    "health": "YELLOW",
+    "qa_verdict": "fail"
   }
 }

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,10 +7,10 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 141,
+    "total_runs": 142,
     "successful_runs": 135,
-    "failed_runs": 1,
-    "success_rate": 0.957,
+    "failed_runs": 2,
+    "success_rate": 0.951,
     "budget_remaining": 0.95,
     "status": "HEALTHY"
   },
@@ -651,8 +651,15 @@
       "tests_total": 1241
     }
   ],
-  "consecutive_qa_failures": 0,
+  "consecutive_qa_failures": 1,
   "history_tail": {
+    "run_id": "2026-04-06-2000",
+    "task": "#93 - Chat: reorder_days intent (E2E scenarios)",
+    "result": "fail",
+    "tests_passed": 1517,
+    "tests_total": 1522
+  },
+  "history_tail_prev2": {
     "run_id": "2026-04-06-1900",
     "task": "#99 - Frontend: chat-first landing + modern UX redesign",
     "result": "success",

--- a/observability/logs/2026-04-06/run-20-00.json
+++ b/observability/logs/2026-04-06/run-20-00.json
@@ -1,0 +1,62 @@
+{
+  "trace": {
+    "run_id": "2026-04-06-2000",
+    "timestamp": "2026-04-06T20:00:00Z",
+    "phase": "Phase 10",
+    "health": "YELLOW",
+    "task": "#93 - Chat: `reorder_days` intent — swap/reorder days via chat (E2E scenarios)",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "fail",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #93 reorder_days E2E; no fix needed; no architect needed"
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "backlog_ready_count=4 >= 2; skipped"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "Added 2 Playwright E2E scenarios in e2e/chat.spec.ts (+168 lines); reorder_days describe block; Scenario A happy path + Scenario B error path using mockChatSession"
+    },
+    {
+      "agent": "qa",
+      "status": "fail",
+      "detail": "3 checks failed: done_criteria_met (backend reorder_days handler not implemented), integration_test_quality (route-mock E2E disqualified by constraint #11), e2e_integration (mockChatSession bypasses server)"
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Recording failure, updating status/backlog/budget, creating PR with evolve-needs-review label"
+    }
+  ],
+  "ltes": {
+    "latency": {
+      "total_duration_ms": 50000
+    },
+    "traffic": {
+      "commits": 1,
+      "lines_added": 168,
+      "lines_removed": 0,
+      "files_changed": 1
+    },
+    "errors": {
+      "test_failures": 3,
+      "fix_attempts": 0,
+      "qa_checks_failed": ["done_criteria_met", "integration_test_quality", "e2e_integration"]
+    },
+    "saturation": {
+      "backlog_remaining": 4
+    }
+  }
+}

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-06T19:00:00Z (Evolve Run #119)
-Run count: 141
+Last run: 2026-04-06T20:00:00Z (Evolve Run #120)
+Run count: 142
 Phase: Phase 10: Chat + Multi-Agent Dashboard — P0 Critical UX Fixes
-Health: GREEN
-Error Budget: HEALTHY
-Tasks completed: 95 (#99 Frontend: chat-first landing + modern UX redesign — style.css created, chat default page, modern visuals)
-Current focus: #93 reorder_days intent
-Next planned: #94 clear_day intent
+Health: YELLOW
+Error Budget: HEALTHY (consecutive_qa_failures=1)
+Tasks completed: 95
+Current focus: #93 reorder_days intent (QA FAILED — backend not implemented + route-mock E2E rejected)
+Next planned: #93 retry (backend handler + integration tests required)
 
 ## LTES Snapshot
 
-- Latency: 48000ms (pytest run + overhead)
+- Latency: 50000ms (pytest run + overhead)
 - Traffic: 1 commit (this run)
-- Errors: 0 test failures (1517/1517 pass), 5 skipped, error_rate=0.0%
-- Saturation: 5 tasks ready
+- Errors: 3 QA check failures (done_criteria_met, integration_test_quality, e2e_integration), error_rate=QA fail
+- Saturation: 4 tasks ready
 
 ## Phase Transition
 
@@ -29,6 +29,19 @@ Next planned: #94 clear_day intent
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #120 — 2026-04-06T20:00:00Z
+- **Task**: #93 - Chat: `reorder_days` intent — swap/reorder days via chat [feature]
+- **Result**: YELLOW ❌ (QA fail)
+- **Tests**: 1517/1517 Python tests passed (no regression), 5 skipped; 2 Playwright E2E scenarios added (+168 lines) but rejected by QA
+- **Files changed**: e2e/chat.spec.ts (+168/-0)
+- **QA failure reasons**:
+  1. `done_criteria_met` FAIL — backend `reorder_days` handler not implemented in `src/app/chat.py`; intent not in supported action list
+  2. `integration_test_quality` FAIL — CLAUDE.md constraint #9 requires integration tests; only route-mock Playwright added
+  3. `e2e_integration` FAIL — CLAUDE.md constraint #11: route-mock E2E (mockChatSession) does not count as integration test
+- **Fix required**: Implement `_handle_reorder_days` in `src/app/chat.py`; add `tests/test_chat_reorder_days.py` with real integration tests
+- **LTES**: L=50000ms T=1 commit E=3 QA failures S=4 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ❌ → reporter ✓
 
 ### Evolve Run #119 — 2026-04-06T19:00:00Z
 - **Task**: #99 - Frontend: chat-first landing + modern UX redesign [improvement]


### PR DESCRIPTION
## Evolve Run #120

- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: YELLOW
- **Task**: #93 - Chat: `reorder_days` intent — swap/reorder days via chat
- **QA**: ❌ FAIL
- **Tests**: 1517/1517 Python passed (no regression), 5 skipped

### Agent Activity

| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #93; no fix or architect needed |
| 📐 Architect | ⏭️ | Skipped (backlog_ready_count=4 ≥ 2) |
| 🔨 Builder | ✅ | Added 2 Playwright E2E scenarios in e2e/chat.spec.ts (+168 lines) |
| 🧪 QA | ❌ | 3 checks failed: done_criteria_met, integration_test_quality, e2e_integration |
| 📝 Reporter | ✅ | This PR |

### QA Failure Details

| Check | Result |
|-------|--------|
| all_tests_pass | ✅ 1517 passed, 5 skipped |
| new_tests_exist | ✅ 2 Playwright scenarios added |
| lint_clean | ✅ ruff clean |
| done_criteria_met | ❌ Backend reorder_days handler not implemented |
| no_regressions | ✅ 1517 same count |
| integration_test_quality | ❌ No Python integration tests (constraint #9) |
| e2e_integration | ❌ Route-mock E2E rejected (constraint #11) |
| no_secrets_leaked | ✅ Clean |

### Issues Found

1. **[Critical]** `reorder_days` not in `src/app/chat.py` supported intents — user messages fall through to `_handle_general`
2. **[High]** No `tests/test_chat_reorder_days.py` — CLAUDE.md constraint #9 requires Python integration tests for all feature tasks
3. **[High]** `mockChatSession` route-mock bypasses server entirely — constraint #11 disqualifies it as integration/E2E test

### Fix Required

- Implement `_handle_reorder_days` in `src/app/chat.py` with: intent parsing, day validation, DB swap, `day_update` SSE events, planner error on out-of-range
- Add `tests/test_chat_reorder_days.py` integration tests (real ChatService, only Gemini mocked)
- Convert at least one Playwright scenario to real-server (no mockChatSession)

다음 실행에서 재시도합니다.

🤖 Auto-generated by Evolve Pipeline