### PR TITLE
fix: #98 UX round 3 — confirm card, KRW display, year fix

### DIFF
--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -126,6 +126,7 @@ class ChatService:
     # ------------------------------------------------------------------
 
     @staticmethod
+    @staticmethod
     def _build_fast_response(message: str) -> str:
         """Build a quick acknowledgment message based on the user's input."""
         msg_lower = message.lower().strip()
@@ -133,14 +134,22 @@ class ChatService:
         greetings = ["안녕", "하이", "hi", "hello", "hey", "ㅎㅇ"]
         if any(msg_lower.startswith(g) for g in greetings):
             return "안녕하세요! 여행 계획을 도와드릴게요 ✨\n"
-        # Plan-related keywords
-        plan_keywords = ["계획", "여행", "일정", "추천", "플랜"]
-        if any(kw in msg_lower for kw in plan_keywords):
-            return "네, 알겠습니다! 확인해볼게요 ✨\n"
+        # Confirmation (for confirm_plan)
+        confirms = ["네", "응", "좋아", "ㅇㅇ", "확인", "세워줘", "진행", "go", "yes"]
+        if any(msg_lower.startswith(c) for c in confirms):
+            return "네, 바로 준비할게요! 🚀\n"
+        # Info-providing (dates, budget, etc.)
+        info_keywords = ["월", "일정", "예산", "만원", "원", "기간", "날짜", "박"]
+        if any(kw in msg_lower for kw in info_keywords):
+            return "네, 알겠습니다! 📝\n"
         # Search-related
         search_keywords = ["검색", "찾아", "호텔", "숙소", "항공", "맛집"]
         if any(kw in msg_lower for kw in search_keywords):
             return "네, 찾아볼게요! 🔍\n"
+        # Plan-related keywords
+        plan_keywords = ["계획", "여행", "추천", "플랜"]
+        if any(kw in msg_lower for kw in plan_keywords):
+            return "네, 알겠습니다! 확인해볼게요 ✨\n"
         # Default
         return "네, 확인해볼게요!\n"
 
@@ -171,7 +180,10 @@ class ChatService:
                 ]
                 context_section = "\n\nPrevious conversation:\n" + "\n".join(lines) + "\n"
 
+            today_str = date.today().isoformat()
             prompt = f"""You are a travel planner AI assistant. Analyze the user message and extract their intent.
+Today's date is {today_str}. When the user mentions dates without a year, assume the current year ({date.today().year}) or next year if the date has already passed.
+The user is based in South Korea. Budget values should be in KRW (Korean Won). Departure city defaults to Seoul (ICN).
 {context_section}
 User message: "{message}"
 
@@ -307,7 +319,7 @@ Return a JSON object with these fields:
 
         # Dispatch to intent handlers, tracking state as events flow
         if intent.action == "create_plan":
-            async for event in self._handle_create_plan(intent):
+            async for event in self._handle_create_plan(intent, session=session):
                 yield _track_and_collect(event)
         elif intent.action == "confirm_plan":
             async for event in self._handle_confirm_plan(intent, session):
@@ -463,11 +475,26 @@ Return a JSON object with these fields:
         breakdown["total"] = result.total_estimated_cost
         return {k: round(v, 2) for k, v in breakdown.items()}
 
-    async def _handle_create_plan(self, intent: Intent) -> AsyncGenerator[dict, None]:
+    _BROAD_REGIONS = {
+        "동남아", "동남아시아", "southeast asia", "유럽", "europe", "미주", "미국",
+        "아시아", "asia", "남미", "south america", "아프리카", "africa",
+        "중동", "middle east", "오세아니아", "oceania", "북미", "north america",
+        "중남미", "latin america", "동유럽", "서유럽", "북유럽", "남유럽",
+    }
+
+    async def _handle_create_plan(self, intent: Intent, session: Optional["ChatSession"] = None) -> AsyncGenerator[dict, None]:
         dest = intent.destination
         budget = intent.budget
         interests = intent.interests or ""
         start, end = self._parse_dates(intent)
+
+        # If destination is too broad (region/continent), ask for a specific city
+        if dest and dest.lower().strip() in self._BROAD_REGIONS:
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"{dest}은(는) 범위가 넓어요! 구체적인 도시를 알려주시겠어요? (예: 방콕, 파리, 도쿄 등)"},
+            }
+            return
 
         # If essential info is missing, ask the user instead of using defaults
         missing = []
@@ -481,6 +508,24 @@ Return a JSON object with these fields:
             ask = "여행 계획을 세우려면 " + ", ".join(missing) + "이(가) 필요해요. 알려주시겠어요?"
             yield {"type": "chat_chunk", "data": {"text": ask}}
             return
+
+        # If not coming from confirm_plan, show confirmation card first
+        if session and not session.pending_plan:
+            pending = {
+                "destination": dest,
+                "start_date": start.isoformat(),
+                "end_date": end.isoformat(),
+                "budget": float(budget),
+                "interests": interests,
+            }
+            session.pending_plan = pending
+            yield {"type": "chat_chunk", "data": {"text": f"{dest} 여행 조건이 준비되었어요! 확인해주세요.\n"}}
+            yield {"type": "confirm_plan", "data": pending}
+            return
+
+        # Clear pending_plan now that we're executing
+        if session:
+            session.pending_plan = None
 
         interests_desc = f", 관심사: {interests}" if interests else ""
         yield {
@@ -3346,9 +3391,14 @@ Return a JSON object with these fields:
             history_lines.append(f"{role}: {content}")
         history_str = "\n".join(history_lines) if history_lines else "(없음)"
 
+        today_str = date.today().isoformat()
+        current_year = date.today().year
+
         prompt = (
             "You are a friendly, knowledgeable travel planning assistant called Travel Planner AI.\n"
-            "Your job is to help users plan trips through natural conversation.\n\n"
+            "Your job is to help users plan trips through natural conversation.\n"
+            f"Today's date is {today_str}. The current year is {current_year}.\n"
+            "The user is based in South Korea. Use KRW (Korean Won) for all budget/cost values.\n\n"
             "Conversation history:\n"
             f"{history_str}\n\n"
             f"User's latest message: \"{intent.raw_message}\"\n\n"

--- a/src/app/static/chat.js
+++ b/src/app/static/chat.js
@@ -656,7 +656,7 @@ function _placeScoutCardHtml(p) {
   return `<div class="search-result-card">
     <div style="display:flex;justify-content:space-between;align-items:center">
       <strong>${escHtml(p.name)}</strong>
-      ${p.estimated_cost ? `<span class="price-tag">$${p.estimated_cost}</span>` : ''}
+      ${p.estimated_cost ? `<span class="price-tag">${Number(p.estimated_cost).toLocaleString()}원</span>` : ''}
     </div>
     ${p.category ? `<div class="meta">${escHtml(p.category)}</div>` : ''}
     ${p.address ? `<div class="meta" style="font-size:.75rem">${escHtml(p.address)}</div>` : ''}
@@ -723,8 +723,8 @@ function _budgetBarHtml(spent, budget) {
   const pct = Math.min(100, (spent / budget) * 100).toFixed(1);
   const barColor = pct >= 90 ? '#dc3545' : pct >= 70 ? '#ffc107' : '#198754';
   return `<div class="budget-row">
-    <span class="meta">예상 비용: <strong>$${Math.round(spent).toLocaleString()}</strong></span>
-    <span class="meta">예산: $${Math.round(budget).toLocaleString()}</span>
+    <span class="meta">예상 비용: <strong>${Math.round(spent).toLocaleString()}원</strong></span>
+    <span class="meta">예산: ${Math.round(budget).toLocaleString()}원</span>
   </div>
   <div class="progress-bar-bg" style="margin:.4rem 0 .2rem">
     <div class="progress-bar" id="plan-budget-bar" style="width:${pct}%;background:${barColor}"></div>
@@ -774,7 +774,7 @@ function _dayCardHtml(day) {
   return `<div class="card day-card" id="day-${escHtml(day.date)}">
     <div style="display:flex;justify-content:space-between;align-items:center">
       <strong>${escHtml(day.date)}</strong>
-      ${dayCost > 0 ? `<span class="price-tag">$${dayCost.toLocaleString()}</span>` : ''}
+      ${dayCost > 0 ? `<span class="price-tag">${dayCost.toLocaleString()}원</span>` : ''}
     </div>
     ${day.notes ? `<div class="meta">${escHtml(day.notes)}</div>` : ''}
     <div class="day-places">${places || '<div class="meta">장소 없음</div>'}</div>
@@ -787,7 +787,7 @@ function _placeItemHtml(p) {
       <span>${escHtml(p.name)}</span>
       ${p.category ? `<span class="meta" style="margin-left:.4rem">(${escHtml(p.category)})</span>` : ''}
     </div>
-    ${p.estimated_cost ? `<span class="price-tag">$${p.estimated_cost}</span>` : ''}
+    ${p.estimated_cost ? `<span class="price-tag">${Number(p.estimated_cost).toLocaleString()}원</span>` : ''}
   </div>`;
 }
 
@@ -812,7 +812,7 @@ function handleDayUpdate(data) {
   const costEl = dayEl.querySelector('.price-tag');
   if (dayCost > 0) {
     if (costEl) {
-      costEl.textContent = `$${dayCost.toLocaleString()}`;
+      costEl.textContent = `${dayCost.toLocaleString()}원`;
     }
   }
 }
@@ -849,7 +849,7 @@ function handleSearchResults(data) {
     itemsHtml = `<div class="budget-breakdown">` +
       cats.map(c => {
         const val = results[c.key];
-        const valStr = (val != null) ? `$${Math.round(val).toLocaleString()}` : '-';
+        const valStr = (val != null) ? `${Math.round(val).toLocaleString()}원` : '-';
         return `<div class="budget-breakdown-row" style="display:flex;justify-content:space-between;padding:.2rem 0${c.key==='total'?';font-weight:bold;border-top:1px solid #ccc;margin-top:.3rem':''}">
           <span>${c.label}</span><span>${valStr}</span></div>`;
       }).join('') +
@@ -932,7 +932,7 @@ function handlePlansList(data) {
     const dest   = escHtml(plan.destination || '');
     const dates  = (plan.start_date && plan.end_date)
       ? `${escHtml(plan.start_date)} → ${escHtml(plan.end_date)}` : '';
-    const budget = plan.budget ? `$${Math.round(plan.budget).toLocaleString()}` : '';
+    const budget = plan.budget ? `${Math.round(plan.budget).toLocaleString()}원` : '';
     const status = plan.status ? escHtml(plan.status) : '';
     html += `<div class="card plan-saved-card" data-plan-id="${escHtml(String(plan.id ?? ''))}"
         style="cursor:pointer;margin-bottom:.5rem" role="button" tabindex="0">

--- a/src/app/static/index.html
+++ b/src/app/static/index.html
@@ -328,7 +328,7 @@ async function renderPlans(app) {
         <button class="btn btn-danger btn-sm" onclick="event.stopPropagation();deletePlan(${p.id})">Delete</button>
       </div>
       <div class="meta">${p.start_date} → ${p.end_date} &nbsp;·&nbsp; ${nights} night${nights!==1?'s':''}</div>
-      <div class="meta">Budget: $${p.budget.toLocaleString()}</div>
+      <div class="meta">예산: ${p.budget.toLocaleString()}원</div>
       ${p.interests ? `<div class="meta">Interests: ${escHtml(p.interests)}</div>` : ''}
     </div>`;
   }
@@ -356,7 +356,7 @@ function renderNewPlan(app) {
         <div><label>Start Date *</label><input name="start_date" type="date" required /></div>
         <div><label>End Date *</label><input name="end_date" type="date" required /></div>
       </div>
-      <label>Budget (USD) *</label>
+      <label>예산 (원) *</label>
       <input name="budget" type="number" min="1" step="any" placeholder="e.g. 3000" required />
       <label>Interests</label>
       <input name="interests" placeholder="e.g. food, culture, nature, museums" />
@@ -424,9 +424,9 @@ async function renderPlanDetail(app, id) {
     budgetBar = `
       <div class="section-title">Budget</div>
       <div style="margin-bottom:.5rem;display:flex;justify-content:space-between;font-size:.875rem">
-        <span>Spent: <strong>$${summary.total_spent.toLocaleString()}</strong></span>
-        <span>Remaining: <strong style="color:${summary.remaining>=0?'var(--success)':'var(--danger)'}">$${summary.remaining.toLocaleString()}</strong></span>
-        <span>Budget: $${summary.budget.toLocaleString()}</span>
+        <span>지출: <strong>${summary.total_spent.toLocaleString()}원</strong></span>
+        <span>잔여: <strong style="color:${summary.remaining>=0?'var(--success)':'var(--danger)'}"> ${summary.remaining.toLocaleString()}원</strong></span>
+        <span>예산: ${summary.budget.toLocaleString()}원</span>
       </div>
       <div class="progress-bar-bg"><div class="progress-bar" style="width:${pct}%;background:${barColor}"></div></div>
       <div style="font-size:.8rem;color:var(--muted);margin-top:.25rem">${pct}% used</div>`;
@@ -446,7 +446,7 @@ async function renderPlanDetail(app, id) {
                 ${p.address?`<div class="meta">${escHtml(p.address)}</div>`:''}
                 ${p.ai_reason?`<div class="meta" style="font-style:italic">${escHtml(p.ai_reason)}</div>`:''}
               </div>
-              ${p.estimated_cost?`<span class="price-tag">$${p.estimated_cost}</span>`:''}
+              ${p.estimated_cost?`<span class="price-tag">${Number(p.estimated_cost).toLocaleString()}원</span>`:''}
             </div>`).join('')
         : '<div class="meta">No places added.</div>';
       itinHtml += `<div class="card">
@@ -478,7 +478,7 @@ async function renderPlanDetail(app, id) {
   <div class="grid2">
     <div class="card">
       <div class="meta">📅 ${plan.start_date} → ${plan.end_date} (${nights} nights)</div>
-      <div class="meta">💰 Budget: $${plan.budget.toLocaleString()}</div>
+      <div class="meta">💰 예산: ${plan.budget.toLocaleString()}원</div>
       ${plan.interests?`<div class="meta">🎯 ${escHtml(plan.interests)}</div>`:''}
       ${budgetBar}
     </div>
@@ -505,7 +505,7 @@ function renderExpenseRows(expenses) {
         ${e.category?`<span class="meta" style="margin-left:.4rem">(${escHtml(e.category)})</span>`:''}
       </div>
       <div style="display:flex;align-items:center;gap:.5rem">
-        <strong>$${e.amount.toLocaleString()}</strong>
+        <strong>${Number(e.amount).toLocaleString()}원</strong>
         <button class="btn btn-danger btn-sm" onclick="deleteExpense(${e.travel_plan_id},${e.id})">×</button>
       </div>
     </div>`).join('');
@@ -524,7 +524,7 @@ function openAddExpense(planId) {
     <div id="exp-alert"></div>
     <form onsubmit="submitExpense(event,${planId})">
       <label>Name *</label><input name="name" required placeholder="e.g. Hotel night" />
-      <label>Amount (USD) *</label><input name="amount" type="number" min="0.01" step="any" required />
+      <label>금액 (원) *</label><input name="amount" type="number" min="0.01" step="any" required />
       <label>Category</label><input name="category" placeholder="e.g. accommodation, food, transport" />
       <label>Date</label><input name="date" type="date" />
       <label>Notes</label><input name="notes" />
@@ -650,7 +650,7 @@ function hotelSearchForm() {
         <div><label>Check-in</label><input name="check_in" type="date" /></div>
         <div><label>Check-out</label><input name="check_out" type="date" /></div>
       </div>
-      <label>Max Price / Night (USD)</label>
+      <label>1박 최대 가격 (원)</label>
       <input name="max_price" type="number" min="1" step="any" placeholder="e.g. 200" />
       <button type="submit" class="btn btn-primary" style="margin-top:1rem">Search Hotels</button>
     </form>
@@ -671,7 +671,7 @@ function flightSearchForm() {
       </div>
       <div class="form-row">
         <div><label>Passengers</label><input name="passengers" type="number" min="1" value="1" /></div>
-        <div><label>Max Budget (USD)</label><input name="max_budget" type="number" min="1" step="any" /></div>
+        <div><label>Max 예산 (원)</label><input name="max_budget" type="number" min="1" step="any" /></div>
       </div>
       <button type="submit" class="btn btn-primary" style="margin-top:1rem">Search Flights</button>
     </form>
@@ -703,7 +703,7 @@ function renderPlaceResults(data) {
     html += `<div class="search-result-card">
       <div style="display:flex;justify-content:space-between;align-items:flex-start">
         <strong>${escHtml(p.name)}</strong>
-        ${p.estimated_cost?`<span class="price-tag">~$${p.estimated_cost}</span>`:''}
+        ${p.estimated_cost?`<span class="price-tag">~${Number(p.estimated_cost).toLocaleString()}원</span>`:''}
       </div>
       ${p.category?`<div class="meta">${escHtml(p.category)}</div>`:''}
       ${p.address?`<div class="meta">📍 ${escHtml(p.address)}</div>`:''}
@@ -738,7 +738,7 @@ function renderHotelResults(data) {
     html += `<div class="search-result-card">
       <div style="display:flex;justify-content:space-between;align-items:flex-start">
         <strong>${escHtml(h.name)}</strong>
-        ${h.price_per_night?`<span class="price-tag">$${h.price_per_night}/night</span>`:''}
+        ${h.price_per_night?`<span class="price-tag">${Number(h.price_per_night).toLocaleString()}원/박</span>`:''}
       </div>
       ${h.address?`<div class="meta">📍 ${escHtml(h.address)}</div>`:''}
       ${h.rating?`<div class="meta">⭐ ${h.rating}</div>`:''}
@@ -778,7 +778,7 @@ function renderFlightResults(data) {
     html += `<div class="search-result-card">
       <div style="display:flex;justify-content:space-between;align-items:flex-start">
         <strong>${escHtml(fl.airline)}</strong>
-        ${fl.price?`<span class="price-tag">$${fl.price}</span>`:''}
+        ${fl.price?`<span class="price-tag">${Number(fl.price).toLocaleString()}원</span>`:''}
       </div>
       ${fl.flight_number?`<div class="meta">Flight ${escHtml(fl.flight_number)}</div>`:''}
       ${fl.departure_time?`<div class="meta">🛫 ${escHtml(fl.departure_time)}${fl.arrival_time?' → 🛬 '+escHtml(fl.arrival_time):''}</div>`:''}

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -229,6 +229,7 @@ class TestProcessMessage:
     def test_create_plan_activates_place_scout(self):
         svc = _make_service_no_api()
         session = svc.create_session()
+        session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 1500000, "interests": ""}
 
         with patch.object(svc, "extract_intent", return_value=Intent(action="create_plan", destination="도쿄", start_date="2026-05-01", end_date="2026-05-03", budget=1500000, raw_message="도쿄")):
             events = _collect_events(svc, session.session_id, "도쿄")
@@ -239,6 +240,7 @@ class TestProcessMessage:
     def test_create_plan_activates_budget_analyst(self):
         svc = _make_service_no_api()
         session = svc.create_session()
+        session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 1500000, "interests": ""}
 
         with patch.object(svc, "extract_intent", return_value=Intent(action="create_plan", destination="도쿄", start_date="2026-05-01", end_date="2026-05-03", budget=1500000, raw_message="도쿄")):
             events = _collect_events(svc, session.session_id, "도쿄")
@@ -492,6 +494,7 @@ class TestServiceHandlerIntegration:
         mock_gemini.generate_itinerary.return_value = _make_fake_itinerary()
         svc = self._make_service_with_mocks(gemini=mock_gemini)
         session = svc.create_session()
+        session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-02", "budget": 1500000, "interests": ""}
 
         with patch.object(svc, "extract_intent", return_value=Intent(
             action="create_plan", destination="도쿄",
@@ -508,6 +511,7 @@ class TestServiceHandlerIntegration:
         mock_gemini.generate_itinerary.return_value = _make_fake_itinerary()
         svc = self._make_service_with_mocks(gemini=mock_gemini)
         session = svc.create_session()
+        session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 1500000, "interests": ""}
 
         with patch.object(svc, "extract_intent", return_value=Intent(
             action="create_plan", destination="도쿄", start_date="2026-05-01", end_date="2026-05-03", budget=1500000, raw_message="도쿄"
@@ -524,6 +528,7 @@ class TestServiceHandlerIntegration:
         mock_gemini.generate_itinerary.return_value = itinerary
         svc = self._make_service_with_mocks(gemini=mock_gemini)
         session = svc.create_session()
+        session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 1500000, "interests": ""}
 
         with patch.object(svc, "extract_intent", return_value=Intent(
             action="create_plan", destination="도쿄", start_date="2026-05-01", end_date="2026-05-03", budget=1500000, raw_message="도쿄"
@@ -538,6 +543,7 @@ class TestServiceHandlerIntegration:
         mock_gemini.generate_itinerary.return_value = _make_fake_itinerary()
         svc = self._make_service_with_mocks(gemini=mock_gemini)
         session = svc.create_session()
+        session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 1500000, "interests": ""}
 
         with patch.object(svc, "extract_intent", return_value=Intent(
             action="create_plan", destination="도쿄", start_date="2026-05-01", end_date="2026-05-03", budget=1500000, raw_message="도쿄"
@@ -560,6 +566,7 @@ class TestServiceHandlerIntegration:
         mock_gemini.generate_itinerary.side_effect = RuntimeError("Gemini unavailable")
         svc = self._make_service_with_mocks(gemini=mock_gemini)
         session = svc.create_session()
+        session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 1500000, "interests": ""}
 
         with patch.object(svc, "extract_intent", return_value=Intent(
             action="create_plan", destination="도쿄", start_date="2026-05-01", end_date="2026-05-03", budget=1500000, raw_message="도쿄"
@@ -973,6 +980,7 @@ class TestGetSessionIncludesAgentStates:
             flight_search_service=MagicMock(),
         )
         session = svc.create_session()
+        session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 1500000, "interests": ""}
         with patch.object(svc, "extract_intent", return_value=Intent(
             action="create_plan", destination="도쿄", start_date="2026-05-01", end_date="2026-05-03", budget=1500000, raw_message="도쿄"
         )):
@@ -1251,6 +1259,7 @@ class TestBudgetBreakdown:
         mock_gemini.generate_itinerary.return_value = _make_fake_itinerary()
         svc = self._make_service_with_gemini(mock_gemini)
         session = svc.create_session()
+        session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 1500000, "interests": ""}
 
         with patch.object(svc, "extract_intent", return_value=Intent(
             action="create_plan", destination="도쿄", start_date="2026-05-01", end_date="2026-05-03", budget=1500000, raw_message="도쿄"
@@ -1269,6 +1278,7 @@ class TestBudgetBreakdown:
         mock_gemini.generate_itinerary.return_value = _make_fake_itinerary()
         svc = self._make_service_with_gemini(mock_gemini)
         session = svc.create_session()
+        session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 1500000, "interests": ""}
 
         with patch.object(svc, "extract_intent", return_value=Intent(
             action="create_plan", destination="도쿄", start_date="2026-05-01", end_date="2026-05-03", budget=1500000, raw_message="도쿄"

--- a/tests/test_chat_dashboard.py
+++ b/tests/test_chat_dashboard.py
@@ -122,6 +122,7 @@ class TestPlanUpdateEventShape:
             raw_message="도쿄",
             **(intent_extra or {}),
         )
+        session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-04", "budget": 2000000.0, "interests": ""}
         with patch.object(svc, "extract_intent", return_value=intent):
             events = _collect(svc, session.session_id, "도쿄")
         plan_events = [e for e in events if e["type"] == "plan_update"]
@@ -192,6 +193,7 @@ class TestDayUpdateEventShape:
             start_date="2026-05-01", end_date="2026-05-02",
             budget=1000.0, raw_message="도쿄",
         )
+        session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-02", "budget": 1000.0, "interests": ""}
         with patch.object(svc, "extract_intent", return_value=intent):
             events = _collect(svc, session.session_id, "도쿄")
         return [e["data"] for e in events if e["type"] == "day_update"]

--- a/tests/test_chat_integration.py
+++ b/tests/test_chat_integration.py
@@ -100,6 +100,7 @@ class TestChatFullFlowIntegration:
         Gemini returns create_plan intent → plan_update event emitted."""
         svc = ChatService(api_key="test-key-for-integration")
         session = svc.create_session()
+        session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-04", "budget": 1500000, "interests": "음식, 문화"}
 
         # Mock only the Gemini HTTP client, not extract_intent
         gemini_intent = {

--- a/tests/test_ux_agent_reasoning.py
+++ b/tests/test_ux_agent_reasoning.py
@@ -95,6 +95,7 @@ class TestCreatePlanReasoning:
         with patch("app.chat.genai.Client", return_value=mock_client):
             svc = ChatService(api_key="fake-key", gemini_service=mock_gemini_svc)
             session = svc.create_session()
+            session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 2000, "interests": ""}
             events = _collect_events(svc, session.session_id, "도쿄 여행")
 
         reasoning_events = [e for e in events if e["type"] == "agent_reasoning"]
@@ -149,6 +150,7 @@ class TestCreatePlanReasoning:
         with patch("app.chat.genai.Client", return_value=mock_client):
             svc = ChatService(api_key="fake-key", gemini_service=mock_gemini_svc)
             session = svc.create_session()
+            session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 1500000, "interests": ""}
             events = _collect_events(svc, session.session_id, "도쿄")
 
         reasoning_events = [e for e in events if e["type"] == "agent_reasoning"]

--- a/tests/test_ux_fast_response.py
+++ b/tests/test_ux_fast_response.py
@@ -139,6 +139,7 @@ class TestFastResponse:
         with patch("app.chat.genai.Client", return_value=mock_client):
             svc = ChatService(api_key="fake-key", gemini_service=mock_gemini_svc)
             session = svc.create_session()
+            session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 2000, "interests": ""}
             events = _collect_events(svc, session.session_id, "도쿄 여행 계획 세워줘")
 
         # There should be a chat_chunk before any agent goes to "working"
@@ -186,6 +187,7 @@ class TestProgressEvents:
         with patch("app.chat.genai.Client", return_value=mock_client):
             svc = ChatService(api_key="fake-key", gemini_service=mock_gemini_svc)
             session = svc.create_session()
+            session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 2000, "interests": ""}
             events = _collect_events(svc, session.session_id, "도쿄 여행")
 
         progress_events = [e for e in events if e["type"] == "progress"]
@@ -240,6 +242,7 @@ class TestProgressEvents:
         with patch("app.chat.genai.Client", return_value=mock_client):
             svc = ChatService(api_key="fake-key", gemini_service=mock_gemini_svc)
             session = svc.create_session()
+            session.pending_plan = {"destination": "도쿄", "start_date": "2026-05-01", "end_date": "2026-05-03", "budget": 1500000, "interests": ""}
             events = _collect_events(svc, session.session_id, "도쿄")
 
         progress_indices = [i for i, e in enumerate(events) if e["type"] == "progress"]


### PR DESCRIPTION
## Summary

- **confirm_plan 강제**: create_plan intent여도 pending_plan 없으면 확인 카드 먼저 표시
- **통화 전환 완료**: 프론트엔드 전체 `$` → `원` (대시보드, 예산바, 검색결과, 비용 표시)
- **날짜 연도 수정**: extract_intent + _general_with_gemini 프롬프트에 오늘 날짜/현재 연도 명시
- **smart fast response**: 맥락별 다른 응답 (확인→🚀, 정보제공→📝, 검색→🔍)
- **넓은 지역명 체크**: 동남아/유럽 등 → 구체적 도시 물어봄

## Test plan

- [x] 1568 tests passed, 12 skipped
- [x] ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)