### PR TITLE
feature: #99 Streaming chat — real-time text for conversation & suggestions

### DIFF
--- a/src/app/ai.py
+++ b/src/app/ai.py
@@ -138,6 +138,54 @@ Be specific, friendly, and concise. Respond in the same language the traveler us
 
         return response.text or "개선 제안을 생성하지 못했습니다."
 
+    def suggest_improvements_stream(
+        self,
+        current_plan: dict,
+        conversation_history: list[dict],
+    ):
+        """Stream improvement suggestions chunk by chunk.
+
+        Returns an iterator of text chunks (google-genai stream response).
+        """
+        if not self._api_key:
+            raise ValueError("GEMINI_API_KEY is not configured")
+
+        import json as _json
+
+        plan_summary = _json.dumps(current_plan, indent=2, default=str) if current_plan else "No plan available yet."
+
+        history_lines = []
+        for entry in conversation_history[-20:]:
+            role = entry.get("role", "user").capitalize()
+            content = entry.get("content", "")
+            history_lines.append(f"{role}: {content}")
+        history_str = "\n".join(history_lines) if history_lines else "No conversation history."
+
+        prompt = f"""You are an expert travel consultant reviewing a traveler's current plan.
+
+Current Travel Plan:
+{plan_summary}
+
+Recent Conversation:
+{history_str}
+
+Please provide 3-5 concrete, actionable improvement suggestions for this travel plan. Focus on:
+- Places that could be added or swapped for better experiences
+- Budget optimization opportunities
+- Logical day sequencing improvements
+- Hidden gems or must-visit spots the traveler might have missed
+
+Be specific, friendly, and concise. Respond in the same language the traveler used."""
+
+        client = genai.Client(api_key=self._api_key)
+        return client.models.generate_content_stream(
+            model=self.MODEL,
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                thinking_config=types.ThinkingConfig(thinking_level="medium"),
+            ),
+        )
+
     def refine_itinerary(
         self,
         destination: str,

--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -3306,8 +3306,8 @@ Return a JSON object with these fields:
         history = list(session.message_history)
 
         try:
-            suggestions = await asyncio.to_thread(
-                self._gemini.suggest_improvements,
+            stream = await asyncio.to_thread(
+                self._gemini.suggest_improvements_stream,
                 current_plan,
                 history,
             )
@@ -3328,14 +3328,19 @@ Return a JSON object with these fields:
                     "message": "예산 분석 완료",
                 },
             }
+
+            # Stream suggestion text chunk by chunk
+            full_text = ""
+            for chunk in stream:
+                if chunk.text:
+                    full_text += chunk.text
+                    yield {"type": "chat_chunk", "data": {"text": chunk.text}}
+
+            suggestions = full_text or "개선 제안을 생성하지 못했습니다."
             parsed = self._parse_suggestions(suggestions)
             yield {
                 "type": "plan_suggestions",
                 "data": {"suggestions": parsed, "raw": suggestions},
-            }
-            yield {
-                "type": "chat_chunk",
-                "data": {"text": suggestions},
             }
 
         except Exception as exc:
@@ -3383,7 +3388,7 @@ Return a JSON object with these fields:
         intent: Intent,
         session: "ChatSession",
     ) -> AsyncGenerator[dict, None]:
-        """Gemini-powered general conversation handler."""
+        """Gemini-powered general conversation handler with streaming."""
         history_lines = []
         for entry in session.message_history[-(_MAX_HISTORY_TURNS * 2):]:
             role = entry.get("role", "user").capitalize()
@@ -3394,7 +3399,8 @@ Return a JSON object with these fields:
         today_str = date.today().isoformat()
         current_year = date.today().year
 
-        prompt = (
+        # Phase 1: Stream the conversational reply (plain text, no JSON)
+        chat_prompt = (
             "You are a friendly, knowledgeable travel planning assistant called Travel Planner AI.\n"
             "Your job is to help users plan trips through natural conversation.\n"
             f"Today's date is {today_str}. The current year is {current_year}.\n"
@@ -3407,34 +3413,55 @@ Return a JSON object with these fields:
             "2. If the user mentions travel-related info (destination, dates, budget, interests), acknowledge it.\n"
             "3. If key info is still missing, ask ONE follow-up question (don't ask for everything at once).\n"
             "4. If the user is just chatting or greeting, be warm and gently steer toward travel planning.\n"
-            "5. Extract any travel details mentioned so far in the conversation.\n\n"
-            "Return a JSON object with exactly these fields:\n"
-            '{"response": "your conversational reply here",'
-            ' "destination": "city/country or null",'
-            ' "start_date": "YYYY-MM-DD or null",'
-            ' "end_date": "YYYY-MM-DD or null",'
-            ' "budget": number_or_null,'
-            ' "interests": "comma-separated or null"}'
+            "5. Keep your response concise and conversational.\n"
         )
 
         try:
             client = genai.Client(api_key=self._api_key)
-            response = await asyncio.to_thread(
-                client.models.generate_content,
+
+            # Stream text chunks to the client in real-time
+            full_reply = ""
+            stream = await asyncio.to_thread(
+                client.models.generate_content_stream,
                 model="gemini-3-flash-preview",
-                contents=prompt,
+                contents=chat_prompt,
                 config=types.GenerateContentConfig(
-                    response_mime_type="application/json",
                     thinking_config=types.ThinkingConfig(thinking_level="low"),
                 ),
             )
-            result = json.loads(response.text)
-            reply = result.get("response", "")
+            for chunk in stream:
+                if chunk.text:
+                    full_reply += chunk.text
+                    yield {"type": "chat_chunk", "data": {"text": chunk.text}}
 
-            if reply:
-                yield {"type": "chat_chunk", "data": {"text": reply}}
+            if not full_reply.strip():
+                yield {"type": "chat_chunk", "data": {"text": "죄송합니다, 응답을 생성하지 못했어요."}}
+                return
 
-            # Check if all key fields are available → emit confirm_plan for user confirmation
+            # Phase 2: Extract travel fields from conversation (lightweight JSON call)
+            extract_prompt = (
+                f"Today's date is {today_str}. Current year is {current_year}.\n"
+                "The user is based in South Korea. Budget values are in KRW.\n"
+                "From the conversation below, extract any travel planning details mentioned so far.\n\n"
+                f"Conversation history:\n{history_str}\n\n"
+                f"User's latest message: \"{intent.raw_message}\"\n"
+                f"Assistant's reply: \"{full_reply[:500]}\"\n\n"
+                "Return a JSON object:\n"
+                '{"destination": "city or null", "start_date": "YYYY-MM-DD or null",'
+                ' "end_date": "YYYY-MM-DD or null", "budget": number_or_null,'
+                ' "interests": "comma-separated or null"}'
+            )
+            extract_resp = await asyncio.to_thread(
+                client.models.generate_content,
+                model="gemini-3-flash-preview",
+                contents=extract_prompt,
+                config=types.GenerateContentConfig(
+                    response_mime_type="application/json",
+                    thinking_config=types.ThinkingConfig(thinking_level="minimal"),
+                ),
+            )
+            result = json.loads(extract_resp.text)
+
             dest = result.get("destination")
             start = result.get("start_date")
             end = result.get("end_date")

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -5985,7 +5985,9 @@ class TestSuggestImprovements:
     def test_suggest_improvements_activates_place_scout(self):
         """place_scout must be activated when suggest_improvements is triggered."""
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.return_value = "여기에 개선 제안이 있습니다."
+        _si_chunk = MagicMock()
+        _si_chunk.text = "여기에 개선 제안이 있습니다."
+        mock_gemini.suggest_improvements_stream.return_value = [_si_chunk]
         svc = self._make_service_with_mocks(gemini=mock_gemini)
         session = svc.create_session()
 
@@ -6000,7 +6002,9 @@ class TestSuggestImprovements:
     def test_suggest_improvements_activates_budget_analyst(self):
         """budget_analyst must be activated when suggest_improvements is triggered."""
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.return_value = "예산 최적화 제안입니다."
+        _si_chunk = MagicMock()
+        _si_chunk.text = "예산 최적화 제안입니다."
+        mock_gemini.suggest_improvements_stream.return_value = [_si_chunk]
         svc = self._make_service_with_mocks(gemini=mock_gemini)
         session = svc.create_session()
 
@@ -6015,7 +6019,9 @@ class TestSuggestImprovements:
     def test_suggest_improvements_emits_chat_chunk(self):
         """A chat_chunk with the suggestions text must be emitted."""
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.return_value = "1. 도쿄 타워 추가 권장\n2. 식비 절감 가능"
+        _si_chunk = MagicMock()
+        _si_chunk.text = "1. 도쿄 타워 추가 권장\n2. 식비 절감 가능"
+        mock_gemini.suggest_improvements_stream.return_value = [_si_chunk]
         svc = self._make_service_with_mocks(gemini=mock_gemini)
         session = svc.create_session()
 
@@ -6032,7 +6038,9 @@ class TestSuggestImprovements:
     def test_suggest_improvements_is_read_only_no_plan_update(self):
         """suggest_improvements must not emit plan_update events (read-only)."""
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.return_value = "몇 가지 제안이 있습니다."
+        _si_chunk = MagicMock()
+        _si_chunk.text = "몇 가지 제안이 있습니다."
+        mock_gemini.suggest_improvements_stream.return_value = [_si_chunk]
         svc = self._make_service_with_mocks(gemini=mock_gemini)
         session = svc.create_session()
 
@@ -6047,7 +6055,9 @@ class TestSuggestImprovements:
     def test_suggest_improvements_calls_gemini_suggest_improvements(self):
         """GeminiService.suggest_improvements must be called with plan and history."""
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.return_value = "좋은 제안입니다."
+        _si_chunk = MagicMock()
+        _si_chunk.text = "좋은 제안입니다."
+        mock_gemini.suggest_improvements_stream.return_value = [_si_chunk]
         svc = self._make_service_with_mocks(gemini=mock_gemini)
         session = svc.create_session()
         # Seed a plan so it's passed to Gemini
@@ -6059,14 +6069,16 @@ class TestSuggestImprovements:
         )):
             _collect_events(svc, session.session_id, "any suggestions?")
 
-        mock_gemini.suggest_improvements.assert_called_once()
-        call_args = mock_gemini.suggest_improvements.call_args[0]
+        mock_gemini.suggest_improvements_stream.assert_called_once()
+        call_args = mock_gemini.suggest_improvements_stream.call_args[0]
         assert call_args[0] == {"destination": "도쿄", "days": [], "budget": 1000.0}
 
     def test_suggest_improvements_place_scout_and_budget_analyst_done_on_success(self):
         """Both place_scout and budget_analyst must reach 'done' status on success."""
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.return_value = "제안 목록입니다."
+        _si_chunk = MagicMock()
+        _si_chunk.text = "제안 목록입니다."
+        mock_gemini.suggest_improvements_stream.return_value = [_si_chunk]
         svc = self._make_service_with_mocks(gemini=mock_gemini)
         session = svc.create_session()
 
@@ -6087,7 +6099,7 @@ class TestSuggestImprovements:
     def test_suggest_improvements_gemini_error_emits_error_status(self):
         """When Gemini fails, error agent_status events must be emitted."""
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.side_effect = RuntimeError("Gemini unavailable")
+        mock_gemini.suggest_improvements_stream.side_effect = RuntimeError("Gemini unavailable")
         svc = self._make_service_with_mocks(gemini=mock_gemini)
         session = svc.create_session()
 
@@ -6105,7 +6117,9 @@ class TestSuggestImprovements:
     def test_suggest_improvements_no_plan_passes_empty_dict(self):
         """When no last_plan exists, suggest_improvements is called with an empty dict."""
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.return_value = "아직 계획이 없어서 제안이 어렵습니다."
+        _si_chunk = MagicMock()
+        _si_chunk.text = "아직 계획이 없어서 제안이 어렵습니다."
+        mock_gemini.suggest_improvements_stream.return_value = [_si_chunk]
         svc = self._make_service_with_mocks(gemini=mock_gemini)
         session = svc.create_session()
         # No last_plan set
@@ -6115,7 +6129,7 @@ class TestSuggestImprovements:
         )):
             _collect_events(svc, session.session_id, "any suggestions?")
 
-        call_args = mock_gemini.suggest_improvements.call_args[0]
+        call_args = mock_gemini.suggest_improvements_stream.call_args[0]
         assert call_args[0] == {}  # empty dict when no plan
 
     def test_suggest_improvements_intent_recognized_from_keyword(self):
@@ -6181,7 +6195,9 @@ class TestPlanSuggestionsEvent:
     def test_plan_suggestions_event_emitted(self):
         """plan_suggestions event must be emitted by suggest_improvements handler."""
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.return_value = "1. Add Tokyo Tower\n2. Try ramen"
+        _si_chunk = MagicMock()
+        _si_chunk.text = "1. Add Tokyo Tower\n2. Try ramen"
+        mock_gemini.suggest_improvements_stream.return_value = [_si_chunk]
         svc = self._make_service(gemini=mock_gemini)
         session = svc.create_session()
 
@@ -6196,7 +6212,9 @@ class TestPlanSuggestionsEvent:
     def test_plan_suggestions_event_contains_suggestions_list(self):
         """plan_suggestions data.suggestions must be a non-empty list."""
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.return_value = "1. Visit Asakusa\n2. Try sushi"
+        _si_chunk = MagicMock()
+        _si_chunk.text = "1. Visit Asakusa\n2. Try sushi"
+        mock_gemini.suggest_improvements_stream.return_value = [_si_chunk]
         svc = self._make_service(gemini=mock_gemini)
         session = svc.create_session()
 
@@ -6213,7 +6231,9 @@ class TestPlanSuggestionsEvent:
         """plan_suggestions data.raw must contain the original AI text."""
         raw_text = "1. First suggestion\n2. Second suggestion"
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.return_value = raw_text
+        _si_chunk = MagicMock()
+        _si_chunk.text = raw_text
+        mock_gemini.suggest_improvements_stream.return_value = [_si_chunk]
         svc = self._make_service(gemini=mock_gemini)
         session = svc.create_session()
 
@@ -6228,9 +6248,9 @@ class TestPlanSuggestionsEvent:
     def test_plan_suggestions_parsed_items_match_input(self):
         """Parsed suggestions list items correspond to the numbered input."""
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.return_value = (
-            "1. Book accommodation early\n2. Visit Nikko for a day trip\n3. Budget for transport"
-        )
+        _si_chunk = MagicMock()
+        _si_chunk.text = "1. Book accommodation early\n2. Visit Nikko for a day trip\n3. Budget for transport"
+        mock_gemini.suggest_improvements_stream.return_value = [_si_chunk]
         svc = self._make_service(gemini=mock_gemini)
         session = svc.create_session()
 
@@ -6246,11 +6266,13 @@ class TestPlanSuggestionsEvent:
             "Budget for transport",
         ]
 
-    def test_plan_suggestions_emitted_before_handler_chat_chunk(self):
-        """plan_suggestions event must be emitted before the handler's chat_chunk
-        (excluding the fast response chunk that comes at the very start)."""
+    def test_plan_suggestions_emitted_after_streamed_chat_chunks(self):
+        """plan_suggestions event must be emitted after the streamed chat_chunks
+        (streaming sends chunks first, then plan_suggestions after full text is collected)."""
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.return_value = "1. suggestion"
+        _si_chunk = MagicMock()
+        _si_chunk.text = "1. suggestion"
+        mock_gemini.suggest_improvements_stream.return_value = [_si_chunk]
         svc = self._make_service(gemini=mock_gemini)
         session = svc.create_session()
 
@@ -6261,14 +6283,16 @@ class TestPlanSuggestionsEvent:
 
         types_seq = [e["type"] for e in events]
         ps_idx = types_seq.index("plan_suggestions")
-        # Find the LAST chat_chunk (handler's result), not the first (fast response)
+        # Find the LAST chat_chunk from stream (handler emits chunks during streaming)
         last_cc_idx = len(types_seq) - 1 - types_seq[::-1].index("chat_chunk")
-        assert ps_idx < last_cc_idx
+        assert ps_idx > last_cc_idx, (
+            "plan_suggestions should come after streamed chat_chunks"
+        )
 
     def test_plan_suggestions_not_emitted_on_gemini_error(self):
         """plan_suggestions must NOT be emitted when Gemini raises an exception."""
         mock_gemini = MagicMock()
-        mock_gemini.suggest_improvements.side_effect = RuntimeError("API down")
+        mock_gemini.suggest_improvements_stream.side_effect = RuntimeError("API down")
         svc = self._make_service(gemini=mock_gemini)
         session = svc.create_session()
 

--- a/tests/test_ux_confirm_plan.py
+++ b/tests/test_ux_confirm_plan.py
@@ -44,16 +44,22 @@ def _make_itinerary_result() -> AIItineraryResult:
     )
 
 
-def _make_gemini_general_response_with_all_fields() -> dict:
-    """Gemini response where all travel fields are extracted."""
+def _make_gemini_extract_response_with_all_fields() -> dict:
+    """Gemini extraction JSON response where all travel fields are extracted."""
     return {
-        "response": "도쿄 5월 여행, 200만원 예산이시군요!",
         "destination": "도쿄",
         "start_date": "2026-05-01",
         "end_date": "2026-05-03",
         "budget": 2000000,
         "interests": "음식, 문화",
     }
+
+
+def _make_stream_chunk(text: str) -> MagicMock:
+    """Create a mock stream chunk with .text attribute."""
+    chunk = MagicMock()
+    chunk.text = text
+    return chunk
 
 
 # ---------------------------------------------------------------------------
@@ -70,11 +76,14 @@ class TestGeneralGeminiConfirmPlan:
         intent_resp = MagicMock()
         intent_resp.text = json.dumps({"action": "general", "raw_message": "도쿄 5월 3일간 200만원"})
 
-        conv_resp = MagicMock()
-        conv_resp.text = json.dumps(_make_gemini_general_response_with_all_fields())
+        extract_resp = MagicMock()
+        extract_resp.text = json.dumps(_make_gemini_extract_response_with_all_fields())
 
         mock_client = MagicMock()
-        mock_client.models.generate_content.side_effect = [intent_resp, conv_resp]
+        mock_client.models.generate_content.side_effect = [intent_resp, extract_resp]
+        mock_client.models.generate_content_stream.return_value = [
+            _make_stream_chunk("도쿄 5월 여행, 200만원 예산이시군요!")
+        ]
 
         with patch("app.chat.genai.Client", return_value=mock_client):
             svc = ChatService(api_key="fake-key")
@@ -92,11 +101,14 @@ class TestGeneralGeminiConfirmPlan:
         intent_resp = MagicMock()
         intent_resp.text = json.dumps({"action": "general", "raw_message": "도쿄"})
 
-        conv_resp = MagicMock()
-        conv_resp.text = json.dumps(_make_gemini_general_response_with_all_fields())
+        extract_resp = MagicMock()
+        extract_resp.text = json.dumps(_make_gemini_extract_response_with_all_fields())
 
         mock_client = MagicMock()
-        mock_client.models.generate_content.side_effect = [intent_resp, conv_resp]
+        mock_client.models.generate_content.side_effect = [intent_resp, extract_resp]
+        mock_client.models.generate_content_stream.return_value = [
+            _make_stream_chunk("도쿄 5월 여행, 200만원 예산이시군요!")
+        ]
 
         with patch("app.chat.genai.Client", return_value=mock_client):
             svc = ChatService(api_key="fake-key")
@@ -116,9 +128,8 @@ class TestGeneralGeminiConfirmPlan:
         intent_resp = MagicMock()
         intent_resp.text = json.dumps({"action": "general", "raw_message": "도쿄 가고 싶어"})
 
-        conv_resp = MagicMock()
-        conv_resp.text = json.dumps({
-            "response": "도쿄 여행이요! 언제쯤 가실 예정인가요?",
+        extract_resp = MagicMock()
+        extract_resp.text = json.dumps({
             "destination": "도쿄",
             "start_date": None,
             "end_date": None,
@@ -127,7 +138,10 @@ class TestGeneralGeminiConfirmPlan:
         })
 
         mock_client = MagicMock()
-        mock_client.models.generate_content.side_effect = [intent_resp, conv_resp]
+        mock_client.models.generate_content.side_effect = [intent_resp, extract_resp]
+        mock_client.models.generate_content_stream.return_value = [
+            _make_stream_chunk("도쿄 여행이요! 언제쯤 가실 예정인가요?")
+        ]
 
         with patch("app.chat.genai.Client", return_value=mock_client):
             svc = ChatService(api_key="fake-key")
@@ -189,11 +203,14 @@ class TestPendingPlanSession:
         intent_resp = MagicMock()
         intent_resp.text = json.dumps({"action": "general", "raw_message": "여행"})
 
-        conv_resp = MagicMock()
-        conv_resp.text = json.dumps(_make_gemini_general_response_with_all_fields())
+        extract_resp = MagicMock()
+        extract_resp.text = json.dumps(_make_gemini_extract_response_with_all_fields())
 
         mock_client = MagicMock()
-        mock_client.models.generate_content.side_effect = [intent_resp, conv_resp]
+        mock_client.models.generate_content.side_effect = [intent_resp, extract_resp]
+        mock_client.models.generate_content_stream.return_value = [
+            _make_stream_chunk("도쿄 5월 여행, 200만원 예산이시군요!")
+        ]
 
         with patch("app.chat.genai.Client", return_value=mock_client):
             svc = ChatService(api_key="fake-key")

--- a/tests/test_ux_fast_response.py
+++ b/tests/test_ux_fast_response.py
@@ -30,15 +30,21 @@ def _collect_events(service: ChatService, session_id: str, message: str) -> list
 
 
 def _make_gemini_mock(intent_dict: dict, conversation_text: str = "안녕하세요!") -> MagicMock:
-    """Create a mock Gemini client that returns intent on first call, conversation on second."""
+    """Create a mock Gemini client that returns intent on first call, streams conversation, then extracts fields."""
     intent_resp = MagicMock()
     intent_resp.text = json.dumps(intent_dict)
 
-    conv_resp = MagicMock()
-    conv_resp.text = json.dumps({"response": conversation_text}) if isinstance(conversation_text, str) else conversation_text
+    # Phase 2 extraction response (no travel fields by default)
+    extract_resp = MagicMock()
+    extract_resp.text = json.dumps({"destination": None, "start_date": None, "end_date": None, "budget": None, "interests": None})
+
+    # Streaming chunk for conversational reply
+    stream_chunk = MagicMock()
+    stream_chunk.text = conversation_text
 
     mock_client = MagicMock()
-    mock_client.models.generate_content.side_effect = [intent_resp, conv_resp]
+    mock_client.models.generate_content.side_effect = [intent_resp, extract_resp]
+    mock_client.models.generate_content_stream.return_value = [stream_chunk]
     return mock_client
 
 
@@ -281,28 +287,31 @@ class TestThinkingConfig:
         assert level_str.upper() == "MINIMAL"
 
     def test_general_conversation_uses_low_thinking(self):
-        """_general_with_gemini should use thinking_level='low' for fast conversation."""
+        """_general_with_gemini should use thinking_level='low' for streaming conversation."""
         intent_resp = MagicMock()
         intent_resp.text = json.dumps({"action": "general", "raw_message": "안녕"})
 
-        conv_resp = MagicMock()
-        conv_resp.text = json.dumps({"response": "안녕하세요!"})
+        stream_chunk = MagicMock()
+        stream_chunk.text = "안녕하세요!"
+
+        extract_resp = MagicMock()
+        extract_resp.text = json.dumps({"destination": None, "start_date": None, "end_date": None, "budget": None, "interests": None})
 
         mock_client = MagicMock()
-        mock_client.models.generate_content.side_effect = [intent_resp, conv_resp]
+        mock_client.models.generate_content.side_effect = [intent_resp, extract_resp]
+        mock_client.models.generate_content_stream.return_value = [stream_chunk]
 
         with patch("app.chat.genai.Client", return_value=mock_client):
             svc = ChatService(api_key="fake-key")
             session = svc.create_session()
             _collect_events(svc, session.session_id, "안녕")
 
-        # Second call is the conversation call
-        calls = mock_client.models.generate_content.call_args_list
-        assert len(calls) >= 2, "Should have at least 2 Gemini calls (intent + conversation)"
-        conv_call = calls[1]
-        # _general_with_gemini uses asyncio.to_thread, so check positional or keyword args
-        config = conv_call.kwargs.get("config") or (conv_call[1].get("config") if len(conv_call) > 1 else None)
-        assert config is not None, "conversation call must have config"
+        # The streaming call should use thinking_level='low'
+        stream_calls = mock_client.models.generate_content_stream.call_args_list
+        assert len(stream_calls) >= 1, "Should have at least 1 streaming call for conversation"
+        stream_call = stream_calls[0]
+        config = stream_call.kwargs.get("config") or (stream_call[1].get("config") if len(stream_call) > 1 else None)
+        assert config is not None, "streaming conversation call must have config"
         assert hasattr(config, "thinking_config"), "config must have thinking_config"
         level = config.thinking_config.thinking_level
         level_str = level.value if hasattr(level, "value") else str(level)


### PR DESCRIPTION
## Summary

- **일반 대화 스트리밍**: `_general_with_gemini`를 2-phase로 분리
  - Phase 1: `generate_content_stream` → 텍스트 실시간 스트리밍 (chat_chunk 즉시 전송)
  - Phase 2: lightweight JSON 호출로 여행 조건 추출 (confirm_plan 판단)
- **개선 제안 스트리밍**: `suggest_improvements_stream` → 제안 텍스트 실시간 출력

## Test plan

- [x] 1568 tests passed, 12 skipped
- [x] ruff lint clean
- [x] 기존 confirm_plan / suggest_improvements 테스트 스트리밍 mock으로 업데이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)