### PR TITLE
fix: #102 Markdown rendering, intent fix, Korean itinerary

### DIFF
--- a/src/app/ai.py
+++ b/src/app/ai.py
@@ -61,7 +61,8 @@ Instructions:
 - Keep total_estimated_cost within the {budget:,.0f}원 budget
 - Provide a brief ai_reason why each place is recommended
 - Use realistic transport options (walking, subway, taxi, bus)
-- Each day's date field must be in YYYY-MM-DD format"""
+- Each day's date field must be in YYYY-MM-DD format
+- IMPORTANT: Write ALL text content in Korean (한국어). This includes: notes, ai_reason, category names, and place descriptions. Place names should use their commonly known Korean names (e.g. "오호리 공원" not "Ohori Park", "후쿠오카 성" not "Fukuoka Castle Ruins")"""
 
     def generate_itinerary(
         self,
@@ -236,7 +237,8 @@ Instructions:
 - Maintain each day's date field in YYYY-MM-DD format
 - Keep total_estimated_cost within the {budget:,.0f}원 budget
 - Preserve unchanged days as-is; only modify days affected by the instruction
-- Each place must have name, category, address, estimated_cost, and ai_reason"""
+- Each place must have name, category, address, estimated_cost, and ai_reason
+- IMPORTANT: Write ALL text content in Korean (한국어). This includes: notes, ai_reason, category names, and place descriptions. Place names should use their commonly known Korean names."""
 
         client = genai.Client(api_key=self._api_key)
         with LLMTimer() as timer:

--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -183,6 +183,8 @@ User message: "{message}"
 Return a JSON object with these fields:
 - action: one of "create_plan", "confirm_plan", "modify_day", "refine_plan", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "add_expense", "update_expense", "update_plan", "get_expense_summary", "delete_expense", "list_expenses", "copy_plan", "get_weather", "reset_conversation", "add_day_note", "suggest_improvements", "remove_place", "add_place", "share_plan", "reorder_days", "clear_day", "general"
 - Use action "confirm_plan" when the user confirms they want to proceed with creating a travel plan (e.g. "네 세워줘", "좋아 계획해줘", "응 진행해", "yes please", "go ahead", "확인")
+- IMPORTANT: Use action "general" for casual conversation, questions, opinions, or when the user is discussing/exploring options but NOT explicitly requesting to create or modify a plan. Examples: "후쿠오카 4박 5일은 너무 길지 않을까?" → general (asking opinion), "여행지 추천해줘" → general (asking for suggestions), "벌레 싫은데" → general (sharing preference)
+- Use "create_plan" ONLY when the user explicitly asks to CREATE a plan with specific details. Use "refine_plan" ONLY when the user explicitly asks to CHANGE an existing plan (e.g. "일정 수정해줘", "3일차 바꿔줘")
 - destination: destination city/country if mentioned or inferred from conversation context, else null
 - start_date: start date in YYYY-MM-DD if mentioned or inferred from context, else null
 - end_date: end date in YYYY-MM-DD if mentioned or inferred from context, else null

--- a/src/app/static/chat.js
+++ b/src/app/static/chat.js
@@ -34,18 +34,35 @@ function _updateAllTimestamps() {
   });
 }
 
+/** Convert simple markdown to HTML (bold, italic, line breaks). */
+function _renderMarkdown(text) {
+  return escHtml(text)
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/\n/g, '<br>');
+}
+
 /** Set the visible text of a bubble (targeting .chat-text if present). */
 function _setBubbleText(bubble, text) {
   const textEl = bubble && bubble.querySelector('.chat-text');
-  if (textEl) textEl.textContent = text;
-  else if (bubble) bubble.textContent = text;
+  if (textEl) {
+    bubble.dataset.rawText = text;
+    textEl.innerHTML = _renderMarkdown(text);
+  } else if (bubble) {
+    bubble.textContent = text;
+  }
 }
 
 /** Append text to a bubble's .chat-text span (for streaming). */
 function _appendBubbleText(bubble, text) {
   const textEl = bubble && bubble.querySelector('.chat-text');
-  if (textEl) textEl.textContent += text;
-  else if (bubble) bubble.textContent += text;
+  if (textEl) {
+    const raw = (bubble.dataset.rawText || '') + text;
+    bubble.dataset.rawText = raw;
+    textEl.innerHTML = _renderMarkdown(raw);
+  } else if (bubble) {
+    bubble.textContent += text;
+  }
 }
 
 /** Show a typing indicator (animated dots) inside a bubble. */


### PR DESCRIPTION
## Summary

- **마크다운 렌더링**: 채팅 말풍선에서 `**bold**` → **bold**, `*italic*` → *italic* HTML 렌더링
- **intent 오분류 수정**: extract_intent 프롬프트에 general vs create_plan/refine_plan 구분 명시. 대화/질문/의견은 general로, 명시적 요청만 plan 액션으로
- **한국어 여행 계획**: generate/refine itinerary에 한국어 작성 지시 추가 (장소명, 설명, 카테고리 전부)

## Test plan

- [x] 1568 tests passed, 12 skipped
- [x] ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)