### PR TITLE
feature: #104 Progressive plan memory — real-time context panel

### DIFF
--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -63,6 +63,7 @@ class ChatSession(BaseModel):
     last_plan: Optional[dict] = None    # last plan_update payload
     last_saved_plan_id: Optional[int] = None  # DB plan_id after save_plan
     pending_plan: Optional[dict] = None  # trip details awaiting user confirmation
+    plan_context: Optional[dict] = None  # progressive travel context (partial info)
 
 
 class ChatService:
@@ -3476,10 +3477,14 @@ Return a JSON object with these fields:
                 f"Conversation history:\n{history_str}\n\n"
                 f"User's latest message: \"{intent.raw_message}\"\n"
                 f"Assistant's reply: \"{full_reply[:500]}\"\n\n"
-                "Return a JSON object:\n"
+                "Return a JSON object with ALL fields (use null if unknown):\n"
                 '{"destination": "city or null", "start_date": "YYYY-MM-DD or null",'
                 ' "end_date": "YYYY-MM-DD or null", "budget": number_or_null,'
-                ' "interests": "comma-separated or null"}'
+                ' "interests": "comma-separated or null",'
+                ' "travel_style": "힐링/액티비티/맛집/문화/쇼핑 or null",'
+                ' "companions": "혼자/커플/가족/친구/부모님 or null",'
+                ' "preferences": ["free-form preference strings"] or null,'
+                ' "departure_city": "departure city or null"}'
             )
             with LLMTimer() as extract_timer:
                 extract_resp = await asyncio.to_thread(
@@ -3500,6 +3505,14 @@ Return a JSON object with these fields:
                 latency_ms=extract_timer.elapsed_ms,
                 extra={"extracted_fields": result},
             )
+
+            # Merge extracted fields into session plan_context (progressive memory)
+            ctx = session.plan_context or {}
+            for key, val in result.items():
+                if val is not None and val != "" and val != []:
+                    ctx[key] = val
+            session.plan_context = ctx
+            yield {"type": "plan_context", "data": ctx}
 
             dest = result.get("destination")
             start = result.get("start_date")
@@ -3591,6 +3604,15 @@ Return a JSON object with these fields:
             yield {"type": "confirm_plan", "data": pending}
             return
 
+        # Emit plan_context with whatever we know so far
+        if known:
+            ctx = session.plan_context or {}
+            for key, val in known.items():
+                if val:
+                    ctx[key] = val
+            session.plan_context = ctx
+            yield {"type": "plan_context", "data": ctx}
+
         # Build acknowledgment of known info + ask for ONE missing piece
         parts = []
         if known.get("destination"):
@@ -3624,6 +3646,8 @@ Return a JSON object with these fields:
         """Clear in-memory conversation history and emit session_reset event."""
         session.history.clear()
         session.message_history.clear()
+        session.plan_context = None
+        session.pending_plan = None
         yield {
             "type": "agent_status",
             "data": {"agent": "coordinator", "status": "done", "message": "대화 내역 초기화 완료"},

--- a/src/app/routers/chat.py
+++ b/src/app/routers/chat.py
@@ -70,6 +70,7 @@ def get_session(session_id: str, db: Session = Depends(get_db)):
         expires_at=session.expires_at,
         agent_states=session.agent_states,
         last_plan=session.last_plan,
+        plan_context=session.plan_context,
         message_history=message_history,
     )
 

--- a/src/app/schemas.py
+++ b/src/app/schemas.py
@@ -269,6 +269,7 @@ class ChatSessionOut(BaseModel):
     expires_at: datetime
     agent_states: dict = {}
     last_plan: Optional[dict] = None
+    plan_context: Optional[dict] = None
     message_history: list[dict] = []
 
 

--- a/src/app/static/chat.js
+++ b/src/app/static/chat.js
@@ -191,9 +191,11 @@ async function restoreSessionState() {
         handleAgentStatus(state);
       }
     }
-    // Restore last plan
+    // Restore last plan (or plan context if no full plan yet)
     if (data.last_plan) {
       handlePlanUpdate(data.last_plan);
+    } else if (data.plan_context) {
+      handlePlanContext(data.plan_context);
     }
     // Restore message bubbles from DB history
     if (data.message_history && data.message_history.length > 0) {
@@ -423,6 +425,9 @@ function handleSseEvent(event) {
         if (el) el.scrollTop = el.scrollHeight;
       }
       break;
+    case 'plan_context':
+      if (event.data) handlePlanContext(event.data);
+      break;
     case 'plan_update':
       if (event.data) handlePlanUpdate(event.data);
       break;
@@ -541,20 +546,43 @@ function resetAgentCards() {
 // Agent panel compact/expanded toggle
 // ---------------------------------------------------------------------------
 
-// Collapses to one compact row when all agents are idle;
-// auto-expands when any agent becomes active.
+// Always shows compact row with active agent names.
+// Full cards panel only shown on explicit click.
 function checkAgentPanelState() {
   const cards = document.querySelectorAll('[data-agent]');
-  const allIdle = Array.from(cards).every(c => c.classList.contains('agent-idle'));
   const compactRow = document.getElementById('agent-panel-compact-row');
   const cardsContainer = document.getElementById('agent-cards');
-  if (!compactRow || !cardsContainer) return;
-  if (allIdle) {
-    compactRow.style.display = 'flex';
-    cardsContainer.style.display = 'none';
+  const label = document.getElementById('agent-panel-compact-label');
+  if (!compactRow || !cardsContainer || !label) return;
+
+  // Always show compact row
+  compactRow.style.display = 'flex';
+
+  // Build active agent summary for compact label
+  const active = [];
+  cards.forEach(c => {
+    const agent = c.dataset.agent;
+    const isActive = c.classList.contains('agent-working') || c.classList.contains('agent-thinking');
+    const isDone = c.classList.contains('agent-done');
+    const msgEl = c.querySelector('.agent-message');
+    const msg = msgEl ? msgEl.textContent : '';
+    if (isActive) {
+      const icon = c.querySelector('.agent-icon');
+      active.push(`${icon ? icon.textContent : ''} ${msg}`);
+    } else if (isDone && msg && msg !== '대기 중') {
+      const icon = c.querySelector('.agent-icon');
+      active.push(`${icon ? icon.textContent : ''}✓`);
+    }
+  });
+
+  if (active.length > 0) {
+    label.textContent = active.join(' · ');
+    compactRow.classList.add('agent-compact-active');
   } else {
-    compactRow.style.display = 'none';
-    cardsContainer.style.display = 'block';
+    label.textContent = 'Team · 전원 대기 중';
+    compactRow.classList.remove('agent-compact-active');
+    // Hide full cards when idle
+    cardsContainer.style.display = 'none';
   }
 }
 
@@ -747,6 +775,54 @@ function _budgetBarHtml(spent, budget) {
     <div class="progress-bar" id="plan-budget-bar" style="width:${pct}%;background:${barColor}"></div>
   </div>
   <div class="meta">${pct}% 사용</div>`;
+}
+
+// ---------------------------------------------------------------------------
+// Progressive Plan Context — builds up as conversation unfolds
+// ---------------------------------------------------------------------------
+
+function handlePlanContext(data) {
+  const panel = document.getElementById('plan-panel');
+  if (!panel) return;
+  // Don't overwrite a full plan with context
+  if (panel.querySelector('.day-card')) return;
+
+  const _field = (icon, label, value) => {
+    if (value) return `<div class="ctx-field ctx-known">${icon} <strong>${escHtml(label)}</strong> ${escHtml(String(value))}</div>`;
+    return `<div class="ctx-field ctx-unknown">${icon} <strong>${escHtml(label)}</strong> <span class="ctx-placeholder">?</span></div>`;
+  };
+
+  // Required fields
+  let budgetStr = null;
+  if (data.budget) budgetStr = Number(data.budget).toLocaleString() + '원';
+  let dateStr = null;
+  if (data.start_date && data.end_date) {
+    dateStr = `${data.start_date} ~ ${data.end_date}`;
+  } else if (data.start_date) {
+    dateStr = `${data.start_date} ~`;
+  }
+
+  let html = `<div class="section-title">✈️ Travel Plan</div>`;
+  html += `<div class="plan-context-card">`;
+  html += _field('📍', '목적지', data.destination);
+  html += _field('📅', '일정', dateStr);
+  html += _field('💰', '예산', budgetStr);
+
+  // Optional tags
+  const tags = [];
+  if (data.travel_style) tags.push(data.travel_style);
+  if (data.companions) tags.push(data.companions);
+  if (data.departure_city) tags.push('출발: ' + data.departure_city);
+  if (data.interests) tags.push(data.interests);
+  if (data.preferences && data.preferences.length) {
+    data.preferences.forEach(p => tags.push(p));
+  }
+  if (tags.length) {
+    html += `<div class="ctx-tags">${tags.map(t => `<span class="ctx-tag">${escHtml(t)}</span>`).join('')}</div>`;
+  }
+
+  html += `</div>`;
+  panel.innerHTML = html;
 }
 
 function handlePlanUpdate(data) {

--- a/src/app/static/index.html
+++ b/src/app/static/index.html
@@ -135,11 +135,22 @@
   .budget-row { display: flex; justify-content: space-between; }
   .day-card { margin-bottom: .75rem; }
   .plan-search-section { margin-top: 1rem; }
-  /* ── Compact agent panel (all-idle collapsed row) ────────────────────────── */
+  /* ── Compact agent panel (always compact, shows active agents inline) ──── */
   #agent-panel-compact-row { display: flex; align-items: center; gap: .5rem; padding: .35rem .5rem;
     cursor: pointer; border-radius: 4px; color: var(--muted); font-size: .875rem; }
   #agent-panel-compact-row:hover { background: var(--bg); }
   #agent-panel-compact-row .compact-expand-hint { margin-left: auto; font-size: .8rem; }
+  .agent-compact-active { color: var(--primary, #2c2c2c); animation: pulse 2s infinite; }
+  /* ── Plan context card (progressive memory) ────────────────────────────── */
+  .plan-context-card { padding: .75rem; }
+  .ctx-field { padding: .4rem 0; font-size: .9rem; display: flex; align-items: center; gap: .4rem; }
+  .ctx-known { color: var(--primary, #2c2c2c); }
+  .ctx-unknown { color: var(--muted, #999); opacity: 0.5; }
+  .ctx-placeholder { font-style: italic; }
+  .ctx-tags { display: flex; flex-wrap: wrap; gap: .35rem; margin-top: .5rem; padding-top: .5rem;
+    border-top: 1px solid var(--border); }
+  .ctx-tag { background: var(--bg, #f5f5f3); padding: .2rem .6rem; border-radius: 12px;
+    font-size: .8rem; color: var(--primary, #2c2c2c); }
   /* ── Mobile responsive: viewport ≤ 768px stacks chat above dashboard ─────── */
   @media (max-width: 768px) {
     .chat-layout { flex-direction: column; height: auto; overflow: visible; }


### PR DESCRIPTION
## Summary

- **Progressive plan context**: 대화 중 수집된 여행 정보가 즉시 우측 패널에 표시
  - 필수: 📍 목적지, 📅 일정, 💰 예산 (있으면 표시, 없으면 `?`)
  - 옵셔널: travel_style, companions, preferences, departure_city → 태그로 표시
  - 새 SSE event `plan_context` — 매 대화 턴마다 부분 정보도 emit
- **Agent panel 컴팩트화**: 항상 1줄, 활성 에이전트 상태 인라인 표시
- **Session 지속성**: plan_context가 세션에 저장, reload 시 복원, reset 시 초기화

## Test plan

- [x] 1568 tests passed, 12 skipped
- [x] ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)