### PR TITLE
feature: #105 Live research dashboard — staggered place cards with photos

### DIFF
--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -13,6 +13,7 @@ from google.genai import types
 from pydantic import BaseModel
 
 from app.ai import GeminiService
+from app.image_resolver import resolve_photo_url, generate_google_maps_url
 from app.llm_logger import log_llm_call, LLMTimer
 from app.calendar_service import CalendarService
 from app.config import GEMINI_API_KEY
@@ -577,6 +578,29 @@ Return a JSON object with these fields:
                     "result_count": place_count,
                 },
             }
+
+            # Emit place_preview cards one by one (staggered for live feel)
+            for day in result.days:
+                for place in day.places:
+                    photo_info = await asyncio.to_thread(
+                        resolve_photo_url, place.name, place.category,
+                    )
+                    yield {
+                        "type": "place_preview",
+                        "data": {
+                            "name": place.name,
+                            "category": place.category,
+                            "address": place.address,
+                            "estimated_cost": place.estimated_cost,
+                            "ai_reason": place.ai_reason,
+                            "day": day.date,
+                            "photo_url": photo_info["photo_url"],
+                            "fallback_icon": photo_info["fallback_icon"],
+                            "google_maps_url": generate_google_maps_url(place.name, place.address),
+                        },
+                    }
+                    await asyncio.sleep(0.15)
+
             breakdown = self._compute_budget_breakdown(result)
             yield {
                 "type": "agent_status",
@@ -584,7 +608,7 @@ Return a JSON object with these fields:
                     "agent": "budget_analyst",
                     "status": "done",
                     "message": f"총 {result.total_estimated_cost:,.0f}원 예산 배분 완료",
-                    "result_count": len(breakdown) - 1,  # exclude "total"
+                    "result_count": len(breakdown) - 1,
                 },
             }
             yield {

--- a/src/app/image_resolver.py
+++ b/src/app/image_resolver.py
@@ -1,0 +1,58 @@
+"""Resolve place images via Wikimedia Commons (free, no API key)."""
+
+import logging
+import urllib.parse
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Category → fallback emoji for places without Wikipedia images
+_CATEGORY_ICONS = {
+    "food": "🍜", "restaurant": "🍜", "cafe": "☕", "bar": "🍺",
+    "sightseeing": "🏛️", "museum": "🏛️", "temple": "⛩️", "shrine": "⛩️",
+    "park": "🌳", "garden": "🌳", "nature": "🌿",
+    "shopping": "🛍️", "market": "🛍️",
+    "hotel": "🏨", "accommodation": "🏨",
+    "transport": "🚇", "station": "🚇",
+    "beach": "🏖️", "island": "🏝️",
+}
+
+
+def _fallback_icon(category: str) -> str:
+    cat = category.lower()
+    for key, icon in _CATEGORY_ICONS.items():
+        if key in cat:
+            return icon
+    return "📍"
+
+
+def resolve_photo_url(place_name: str, category: str = "") -> dict:
+    """Look up a Wikipedia thumbnail for a place.
+
+    Returns {"photo_url": "https://..." or "", "fallback_icon": "🏛️"}.
+    """
+    fallback = _fallback_icon(category)
+    try:
+        encoded = urllib.parse.quote(place_name)
+        url = (
+            f"https://en.wikipedia.org/w/api.php"
+            f"?action=query&titles={encoded}&prop=pageimages"
+            f"&format=json&pithumbsize=400&redirects=1"
+        )
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+        pages = resp.json().get("query", {}).get("pages", {})
+        for page in pages.values():
+            thumb = page.get("thumbnail", {}).get("source")
+            if thumb:
+                return {"photo_url": thumb, "fallback_icon": fallback}
+    except Exception as exc:
+        logger.debug("image_resolver: %s — %s", place_name, exc)
+    return {"photo_url": "", "fallback_icon": fallback}
+
+
+def generate_google_maps_url(name: str, address: str = "") -> str:
+    """Generate a Google Maps search deep link."""
+    query = f"{name} {address}".strip()
+    return f"https://www.google.com/maps/search/?api=1&query={urllib.parse.quote(query)}"

--- a/src/app/static/chat.js
+++ b/src/app/static/chat.js
@@ -428,6 +428,9 @@ function handleSseEvent(event) {
     case 'plan_context':
       if (event.data) handlePlanContext(event.data);
       break;
+    case 'place_preview':
+      if (event.data) handlePlacePreview(event.data);
+      break;
     case 'plan_update':
       if (event.data) handlePlanUpdate(event.data);
       break;
@@ -780,6 +783,52 @@ function _budgetBarHtml(spent, budget) {
 // ---------------------------------------------------------------------------
 // Progressive Plan Context — builds up as conversation unfolds
 // ---------------------------------------------------------------------------
+
+function handlePlacePreview(data) {
+  const panel = document.getElementById('plan-panel');
+  if (!panel) return;
+
+  // Ensure a place-cards grid container exists
+  let grid = panel.querySelector('.place-cards-grid');
+  if (!grid) {
+    // Clear the empty/context state, add header + grid
+    const contextCard = panel.querySelector('.plan-context-card');
+    if (!contextCard) {
+      panel.innerHTML = '<div class="section-title">✈️ Travel Plan</div>';
+    }
+    grid = document.createElement('div');
+    grid.className = 'place-cards-grid';
+    panel.appendChild(grid);
+  }
+
+  // Build card
+  const card = document.createElement('a');
+  card.className = 'place-card place-card-enter';
+  card.href = data.google_maps_url || '#';
+  card.target = '_blank';
+  card.rel = 'noopener';
+
+  const photoHtml = data.photo_url
+    ? `<div class="place-card-photo" style="background-image:url('${escHtml(data.photo_url)}')"></div>`
+    : `<div class="place-card-photo place-card-photo-fallback">${data.fallback_icon || '📍'}</div>`;
+
+  const costStr = data.estimated_cost
+    ? `<span class="price-tag">${Number(data.estimated_cost).toLocaleString()}원</span>`
+    : '';
+
+  card.innerHTML = `
+    ${photoHtml}
+    <div class="place-card-body">
+      <div class="place-card-name">${escHtml(data.name)}</div>
+      <div class="place-card-meta">${escHtml(data.category || '')} ${costStr}</div>
+      ${data.ai_reason ? `<div class="place-card-reason">${escHtml(data.ai_reason)}</div>` : ''}
+    </div>`;
+
+  grid.appendChild(card);
+  // Trigger animation after DOM insert
+  requestAnimationFrame(() => card.classList.remove('place-card-enter'));
+  panel.scrollTop = panel.scrollHeight;
+}
 
 function handlePlanContext(data) {
   const panel = document.getElementById('plan-panel');

--- a/src/app/static/index.html
+++ b/src/app/static/index.html
@@ -151,6 +151,27 @@
     border-top: 1px solid var(--border); }
   .ctx-tag { background: var(--bg, #f5f5f3); padding: .2rem .6rem; border-radius: 12px;
     font-size: .8rem; color: var(--primary, #2c2c2c); }
+  /* ── Place preview cards (live research dashboard) ─────────────────────── */
+  .place-cards-grid { display: grid; grid-template-columns: 1fr 1fr; gap: .5rem;
+    margin-top: .75rem; }
+  .place-card { display: flex; flex-direction: column; border: 1px solid var(--border);
+    border-radius: 8px; overflow: hidden; text-decoration: none; color: inherit;
+    background: white; transition: transform 0.15s, box-shadow 0.15s, opacity 0.3s;
+    opacity: 1; transform: translateY(0); }
+  .place-card:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,.1); }
+  .place-card-enter { opacity: 0; transform: translateY(12px); }
+  .place-card-photo { height: 80px; background-size: cover; background-position: center;
+    background-color: var(--bg, #f5f5f3); }
+  .place-card-photo-fallback { display: flex; align-items: center; justify-content: center;
+    font-size: 2rem; }
+  .place-card-body { padding: .5rem; }
+  .place-card-name { font-size: .85rem; font-weight: 600; margin-bottom: .15rem; }
+  .place-card-meta { font-size: .75rem; color: var(--muted); display: flex;
+    justify-content: space-between; align-items: center; }
+  .place-card-reason { font-size: .7rem; color: var(--muted); margin-top: .25rem;
+    line-height: 1.3; display: -webkit-box; -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical; overflow: hidden; }
+  @media (max-width: 768px) { .place-cards-grid { grid-template-columns: 1fr; } }
   /* ── Mobile responsive: viewport ≤ 768px stacks chat above dashboard ─────── */
   @media (max-width: 768px) {
     .chat-layout { flex-direction: column; height: auto; overflow: visible; }


### PR DESCRIPTION
## Summary

AI가 리서치하는 과정이 눈에 보이는 라이브 대시보드:

- **장소 카드 stagger 등장**: 여행 계획 생성 시 장소가 150ms 간격으로 1개씩 등장. slideUp + fadeIn 애니메이션.
- **Wikimedia 사진**: Wikipedia 썸네일 자동 조회 (무료, API key 불필요). 없으면 카테고리 이모지 폴백.
- **Google Maps 딥링크**: 카드 클릭 → Google Maps 검색 새 탭
- **2열 그리드 카드**: 사진 + 이름 + 카테고리 + 비용 + AI 추천이유

## Test plan

- [x] 1568 tests passed, 12 skipped
- [x] ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)