### PR TITLE
fix: #106 confirm_plan without pending_plan → conversational AI

### DIFF
--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -655,10 +655,9 @@ Return a JSON object with these fields:
         """Handle confirm_plan: create plan from pending_plan stored in session."""
         pending = session.pending_plan
         if not pending:
-            yield {
-                "type": "chat_chunk",
-                "data": {"text": "아직 확정할 여행 조건이 없어요. 어디로 가고 싶으신지부터 얘기해볼까요? 😊"},
-            }
+            # No pending plan — delegate to conversational AI instead of hardcoded response
+            async for event in self._general_with_gemini(intent, session):
+                yield event
             return
 
         confirmed_intent = Intent(


### PR DESCRIPTION
## Summary

- `_handle_confirm_plan`에서 `pending_plan`이 없을 때 하드코딩 응답 대신 `_general_with_gemini`로 위임
- "호캉스 ㄱㄱ" → confirm_plan으로 분류됐지만 예산 미수집 → 대화 context 유실되던 버그 수정

## Root cause

"ㄱㄱ"이 confirm_plan으로 분류 → pending_plan=None → "아직 확정할 여행 조건이 없어요" 반복

## Test plan

- [x] 1568 tests passed, 12 skipped
- [x] ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)