### PR TITLE
feature: #101 Chat move_place intent — move a place from one day to another (#101)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -12,12 +12,6 @@ _(없음)_
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
 
-- [ ] #101 - Chat: `move_place` intent — move a place from one day to another [feature]
-  - ref: markdowns/feat-chat-dashboard.md
-  - files: src/app/chat.py, tests/test_chat.py
-  - done: "1일차 두 번째 장소를 3일차로 옮겨줘" → place removed from source, appended to target; day_update SSE for both days; error when day/place not found; 2+ tests
-  - gh: #139
-
 - [ ] #102 - Chat: `set_day_label` intent — set a custom title/label for a day [feature]
   - ref: markdowns/feat-chat-dashboard.md
   - files: src/app/chat.py, src/app/schemas.py, tests/test_chat.py
@@ -156,6 +150,7 @@ _(없음)_
 - [x] #95 - Frontend: message timestamp display in chat bubbles [improvement] — 2026-04-07
 - [x] #96 - Chat: `duplicate_day` intent — copy a day's itinerary to another day [feature] — 2026-04-07
 - [x] #100 - E2E: `duplicate_day` Playwright scenarios [test] — 2026-04-07
+- [x] #101 - Chat: `move_place` intent — move a place from one day to another [feature] — 2026-04-07
 
 ### Phase 9: User Experience & Polish (remaining, completed)
 - [x] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature] — 2026-04-04
@@ -168,5 +163,5 @@ _(없음)_
 ## Metrics
 
 - Velocity: 1 task/run
-- Total tasks: 101 done, 4 ready (0 in progress)
+- Total tasks: 102 done, 3 ready (0 in progress)
 - Phase: 10 (Chat + Multi-Agent Dashboard)

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,11 +1,11 @@
 {
-  "last_updated": "2026-04-07T15:00:00Z",
+  "last_updated": "2026-04-07T16:00:00Z",
   "summary": {
-    "total_runs": 151,
-    "total_commits": 163,
-    "total_tests": 1576,
-    "tasks_completed": 101,
-    "tasks_remaining": 4,
+    "total_runs": 152,
+    "total_commits": 164,
+    "total_tests": 1587,
+    "tasks_completed": 102,
+    "tasks_remaining": 3,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
     "health": "GREEN"
   },
@@ -66,11 +66,11 @@
     },
     {
       "date": "2026-04-07",
-      "runs": 6,
-      "tasks_completed": 4,
-      "tests_passed": 1576,
+      "runs": 7,
+      "tasks_completed": 5,
+      "tests_passed": 1587,
       "tests_failed": 0,
-      "commits": 29,
+      "commits": 30,
       "health": "GREEN"
     }
   ],
@@ -87,10 +87,10 @@
     "health": "GREEN"
   },
   "last_evolve": {
-    "timestamp": "2026-04-07T15:00:00Z",
-    "run_id": "2026-04-07-1500",
-    "task": "#100 - E2E: duplicate_day Playwright scenarios",
-    "tests_passed": 1576,
+    "timestamp": "2026-04-07T16:00:00Z",
+    "run_id": "2026-04-07-1600",
+    "task": "#101 - Chat: move_place intent — move a place from one day to another",
+    "tests_passed": 1587,
     "tests_failed": 0,
     "health": "GREEN",
     "qa_verdict": "pass"

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,10 +7,10 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 151,
-    "successful_runs": 145,
+    "total_runs": 152,
+    "successful_runs": 146,
     "failed_runs": 1,
-    "success_rate": 0.960,
+    "success_rate": 0.961,
     "budget_remaining": 0.95,
     "status": "HEALTHY"
   },
@@ -653,11 +653,11 @@
   ],
   "consecutive_qa_failures": 0,
   "history_tail": {
-    "run_id": "2026-04-07-1500",
-    "task": "#100 - E2E: duplicate_day Playwright scenarios",
+    "run_id": "2026-04-07-1600",
+    "task": "#101 - Chat: move_place intent — move a place from one day to another",
     "result": "success",
-    "tests_passed": 1576,
-    "tests_total": 1576
+    "tests_passed": 1587,
+    "tests_total": 1587
   },
   "history_tail_prev2": {
     "run_id": "monitor-2026-04-07-1451",
@@ -667,10 +667,10 @@
     "tests_total": 1588
   },
   "history_tail_prev": {
-    "run_id": "2026-04-07-0200",
-    "task": "#96 - Chat: duplicate_day intent — copy a day's itinerary to another day",
+    "run_id": "2026-04-07-1500",
+    "task": "#100 - E2E: duplicate_day Playwright scenarios",
     "result": "success",
     "tests_passed": 1576,
-    "tests_total": 1588
+    "tests_total": 1576
   }
 }

--- a/observability/logs/2026-04-07/run-16-00.json
+++ b/observability/logs/2026-04-07/run-16-00.json
@@ -1,0 +1,61 @@
+{
+  "trace": {
+    "run_id": "2026-04-07-1600",
+    "timestamp": "2026-04-07T16:00:00Z",
+    "phase": "Phase 10 (Chat + Multi-Agent Dashboard)",
+    "health": "GREEN",
+    "task": "#101 - Chat: move_place intent — move a place from one day to another",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "pass",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #101 move_place; health GREEN; no architect needed (backlog_ready_count=3)"
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "Ready tasks >= 2, architect not triggered"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "Implemented move_place intent handler in src/app/chat.py (+290/-2); 11 new tests in tests/test_chat.py (9 in-memory + 2 DB integration)"
+    },
+    {
+      "agent": "qa",
+      "status": "pass",
+      "detail": "1587/1587 passed, 12 skipped; all checks pass: tests, lint, done_criteria, no_regressions, integration_test_quality, e2e_integration, no_secrets_leaked"
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Writing logs, updating status/backlog/budget, creating PR"
+    }
+  ],
+  "ltes": {
+    "latency": {
+      "total_duration_ms": 50000
+    },
+    "traffic": {
+      "commits": 1,
+      "lines_added": 290,
+      "lines_removed": 2,
+      "files_changed": 2
+    },
+    "errors": {
+      "test_failures": 0,
+      "fix_attempts": 0
+    },
+    "saturation": {
+      "backlog_remaining": 3
+    }
+  }
+}

--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -35,7 +35,7 @@ _DEFAULT_DEPARTURE = "서울(ICN)"  # default origin for flight search
 
 
 class Intent(BaseModel):
-    action: str  # create_plan | confirm_plan | modify_day | refine_plan | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | delete_plan | view_plan | add_expense | update_expense | update_plan | get_expense_summary | delete_expense | list_expenses | copy_plan | get_weather | reset_conversation | add_day_note | suggest_improvements | remove_place | add_place | share_plan | reorder_days | clear_day | duplicate_day | general
+    action: str  # create_plan | confirm_plan | modify_day | refine_plan | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | delete_plan | view_plan | add_expense | update_expense | update_plan | get_expense_summary | delete_expense | list_expenses | copy_plan | get_weather | reset_conversation | add_day_note | suggest_improvements | remove_place | add_place | share_plan | reorder_days | clear_day | duplicate_day | move_place | general
     destination: Optional[str] = None
     start_date: Optional[str] = None
     end_date: Optional[str] = None
@@ -188,7 +188,7 @@ The user is based in South Korea. Budget values should be in KRW (Korean Won). D
 User message: "{message}"
 
 Return a JSON object with these fields:
-- action: one of "create_plan", "confirm_plan", "modify_day", "refine_plan", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "add_expense", "update_expense", "update_plan", "get_expense_summary", "delete_expense", "list_expenses", "copy_plan", "get_weather", "reset_conversation", "add_day_note", "suggest_improvements", "remove_place", "add_place", "share_plan", "reorder_days", "clear_day", "duplicate_day", "general"
+- action: one of "create_plan", "confirm_plan", "modify_day", "refine_plan", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "add_expense", "update_expense", "update_plan", "get_expense_summary", "delete_expense", "list_expenses", "copy_plan", "get_weather", "reset_conversation", "add_day_note", "suggest_improvements", "remove_place", "add_place", "share_plan", "reorder_days", "clear_day", "duplicate_day", "move_place", "general"
 - Use action "confirm_plan" when the user confirms they want to proceed with creating a travel plan (e.g. "네 세워줘", "좋아 계획해줘", "응 진행해", "yes please", "go ahead", "확인")
 - IMPORTANT: Use action "general" for casual conversation, questions, opinions, or when the user is discussing/exploring options but NOT explicitly requesting to create or modify a plan. Examples: "후쿠오카 4박 5일은 너무 길지 않을까?" → general (asking opinion), "여행지 추천해줘" → general (asking for suggestions), "벌레 싫은데" → general (sharing preference)
 - Use "create_plan" ONLY when the user explicitly asks to CREATE a plan with specific details. Use "refine_plan" ONLY when the user explicitly asks to CHANGE an existing plan (e.g. "일정 수정해줘", "3일차 바꿔줘")
@@ -220,6 +220,7 @@ Return a JSON object with these fields:
 - day_number_2: second day number for reorder_days swap or duplicate_day target (e.g. "1일차와 3일차 바꿔줘" → day_number=1, day_number_2=3; "2일차를 4일차에 복사" → day_number=2, day_number_2=4); null for all other actions
 - Use action "clear_day" when user wants to remove ALL places from a specific day (e.g. "3일차 일정 다 지워줘", "Day 2 일정 전부 삭제", "2일차 장소 모두 제거", "clear all places from day 3", "day 1 일정 비워줘"); set day_number to the referenced day
 - Use action "duplicate_day" when user wants to copy all places from one day to another day (e.g. "2일차 일정을 4일차에도 넣어줘", "1일차 복사해서 3일차에 붙여줘", "Day 2 일정을 Day 4로 복사", "copy day 1 to day 3", "2일차랑 똑같이 4일차도 만들어줘"); set day_number to the SOURCE day and day_number_2 to the TARGET day
+- Use action "move_place" when user wants to move/transfer a specific place from one day to another day (e.g. "1일차 두 번째 장소를 3일차로 옮겨줘", "Day 2에서 센소지를 Day 4로 이동해줘", "3일차 첫 번째 장소를 1일차로 옮겨", "move place from day 1 to day 3", "2일차 루브르를 3일차로 이동"); set day_number to the SOURCE day, day_number_2 to the TARGET day, query to the place name if mentioned, and place_index to the 1-based position if an ordinal is mentioned (e.g. "첫 번째" → 1, "두 번째" → 2, "마지막" → -1)
 - raw_message: the exact original message"""
 
             client = genai.Client(api_key=self._api_key)
@@ -416,6 +417,9 @@ Return a JSON object with these fields:
                 yield _track_and_collect(event)
         elif intent.action == "duplicate_day":
             async for event in self._handle_duplicate_day(intent, session, db):
+                yield _track_and_collect(event)
+        elif intent.action == "move_place":
+            async for event in self._handle_move_place(intent, session, db):
                 yield _track_and_collect(event)
         else:  # general
             async for event in self._handle_general(intent, session):
@@ -2926,6 +2930,268 @@ Return a JSON object with these fields:
             yield {
                 "type": "chat_chunk",
                 "data": {"text": "일정을 복사하려면 먼저 여행 계획을 만들거나 저장해주세요."},
+            }
+
+    async def _handle_move_place(
+        self,
+        intent: Intent,
+        session: "ChatSession",
+        db: Optional["Session"] = None,
+    ) -> AsyncGenerator[dict, None]:
+        """Move a specific place from a source day to a target day.
+
+        Reads day_number (source), day_number_2 (target), and place_index / query
+        from intent. Removes the place from the source day and appends it to the
+        target day. Emits day_update for BOTH the source and target days.
+        Returns an error chat_chunk when day numbers are missing, out of range,
+        or the specified place is not found.
+        """
+        src = intent.day_number
+        tgt = intent.day_number_2
+        place_name = intent.query
+        place_index = intent.place_index  # 1-based
+
+        yield {
+            "type": "agent_status",
+            "data": {"agent": "planner", "status": "working", "message": "장소 이동 중..."},
+        }
+        await asyncio.sleep(0)
+
+        if not src or not tgt:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "planner", "status": "error", "message": "이동할 출발 날짜와 대상 날짜를 지정해주세요"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": "이동할 날짜(예: '1일차 두 번째 장소를 3일차로')를 알려주세요."},
+            }
+            return
+
+        if src == tgt:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "planner", "status": "done", "message": "같은 날짜입니다"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"Day {src}와 Day {tgt}는 동일한 날짜입니다."},
+            }
+            return
+
+        plan_id: Optional[int] = intent.plan_id or session.last_saved_plan_id
+
+        if db is not None and plan_id is not None:
+            try:
+                from app.models import (
+                    DayItinerary as DayItineraryModel,
+                    TravelPlan as TravelPlanModel,
+                )
+
+                plan = db.get(TravelPlanModel, plan_id)
+                if plan is None:
+                    yield {
+                        "type": "agent_status",
+                        "data": {"agent": "planner", "status": "error", "message": f"계획 #{plan_id}을 찾을 수 없습니다"},
+                    }
+                    yield {
+                        "type": "chat_chunk",
+                        "data": {"text": f"계획 #{plan_id}을 찾을 수 없습니다."},
+                    }
+                    return
+
+                days = (
+                    db.query(DayItineraryModel)
+                    .filter(DayItineraryModel.travel_plan_id == plan_id)
+                    .order_by(DayItineraryModel.date)
+                    .all()
+                )
+
+                total = len(days)
+                for day_num in (src, tgt):
+                    if day_num < 1 or day_num > total:
+                        yield {
+                            "type": "agent_status",
+                            "data": {"agent": "planner", "status": "error", "message": f"Day {day_num}이 범위를 벗어났습니다"},
+                        }
+                        yield {
+                            "type": "chat_chunk",
+                            "data": {"text": f"Day {day_num}은 이 계획에 없습니다 (총 {total}일)."},
+                        }
+                        return
+
+                day_obj_src = days[src - 1]
+                day_obj_tgt = days[tgt - 1]
+
+                src_places = sorted(day_obj_src.places, key=lambda x: x.order)
+
+                # Find the place to move
+                target_place = None
+                if place_name:
+                    name_lower = place_name.lower()
+                    for p in src_places:
+                        if name_lower in p.name.lower():
+                            target_place = p
+                            break
+                elif place_index is not None:
+                    actual_idx = len(src_places) + place_index if place_index < 0 else place_index - 1
+                    if 0 <= actual_idx < len(src_places):
+                        target_place = src_places[actual_idx]
+                elif src_places:
+                    target_place = src_places[0]
+
+                if target_place is None:
+                    not_found = place_name or (f"#{place_index}" if place_index else "장소")
+                    yield {
+                        "type": "agent_status",
+                        "data": {"agent": "planner", "status": "error", "message": f"'{not_found}' 장소를 찾을 수 없습니다"},
+                    }
+                    yield {
+                        "type": "chat_chunk",
+                        "data": {"text": f"Day {src}에서 '{not_found}'을 찾을 수 없습니다."},
+                    }
+                    return
+
+                moved_name = target_place.name
+
+                # Determine new order for target day
+                tgt_places = sorted(day_obj_tgt.places, key=lambda x: x.order)
+                new_order = (tgt_places[-1].order + 1) if tgt_places else 0
+
+                # Move: change the place's day_itinerary_id to target day
+                target_place.day_itinerary_id = day_obj_tgt.id
+                target_place.order = new_order
+
+                db.commit()
+                db.refresh(day_obj_src)
+                db.refresh(day_obj_tgt)
+
+                def _places_data(day_obj):
+                    return [
+                        {
+                            "name": p.name,
+                            "category": p.category,
+                            "address": p.address,
+                            "estimated_cost": p.estimated_cost,
+                            "ai_reason": p.ai_reason,
+                            "order": p.order,
+                        }
+                        for p in sorted(day_obj.places, key=lambda x: x.order)
+                    ]
+
+                yield {
+                    "type": "day_update",
+                    "data": {
+                        "day_number": src,
+                        "date": day_obj_src.date.isoformat(),
+                        "notes": day_obj_src.notes,
+                        "transport": day_obj_src.transport,
+                        "places": _places_data(day_obj_src),
+                    },
+                }
+                yield {
+                    "type": "day_update",
+                    "data": {
+                        "day_number": tgt,
+                        "date": day_obj_tgt.date.isoformat(),
+                        "notes": day_obj_tgt.notes,
+                        "transport": day_obj_tgt.transport,
+                        "places": _places_data(day_obj_tgt),
+                    },
+                }
+                yield {
+                    "type": "agent_status",
+                    "data": {"agent": "planner", "status": "done", "message": f"Day {src} → Day {tgt} '{moved_name}' 이동 완료!"},
+                }
+                yield {
+                    "type": "chat_chunk",
+                    "data": {"text": f"Day {src}의 '{moved_name}'을 Day {tgt}로 이동했습니다."},
+                }
+
+            except Exception as exc:
+                logger.error("_handle_move_place: failed — %s: %s", type(exc).__name__, exc, exc_info=True)
+                yield {
+                    "type": "agent_status",
+                    "data": {"agent": "planner", "status": "error", "message": "장소 이동 실패"},
+                }
+                yield {
+                    "type": "chat_chunk",
+                    "data": {"text": f"장소 이동 중 오류가 발생했습니다: {exc}"},
+                }
+        else:
+            # In-memory plan
+            last_plan = session.last_plan
+            if last_plan:
+                days = last_plan.get("days", [])
+                total = len(days)
+                for day_num in (src, tgt):
+                    if day_num < 1 or day_num > total:
+                        yield {
+                            "type": "agent_status",
+                            "data": {"agent": "planner", "status": "error", "message": f"Day {day_num}이 범위를 벗어났습니다"},
+                        }
+                        yield {
+                            "type": "chat_chunk",
+                            "data": {"text": f"Day {day_num}은 이 계획에 없습니다 (총 {total}일)."},
+                        }
+                        return
+
+                day_obj_src = days[src - 1]
+                day_obj_tgt = days[tgt - 1]
+                src_places = day_obj_src.get("places", [])
+
+                # Find the place to move
+                target_idx = None
+                if place_name:
+                    name_lower = place_name.lower()
+                    for i, p in enumerate(src_places):
+                        if name_lower in p.get("name", "").lower():
+                            target_idx = i
+                            break
+                elif place_index is not None:
+                    actual_idx = len(src_places) + place_index if place_index < 0 else place_index - 1
+                    if 0 <= actual_idx < len(src_places):
+                        target_idx = actual_idx
+                elif src_places:
+                    target_idx = 0
+
+                if target_idx is None:
+                    not_found = place_name or (f"#{place_index}" if place_index else "장소")
+                    yield {
+                        "type": "agent_status",
+                        "data": {"agent": "planner", "status": "error", "message": f"'{not_found}' 장소를 찾을 수 없습니다"},
+                    }
+                    yield {
+                        "type": "chat_chunk",
+                        "data": {"text": f"Day {src}에서 '{not_found}'을 찾을 수 없습니다."},
+                    }
+                    return
+
+                import copy
+                moved_place = src_places.pop(target_idx)
+                moved_name = moved_place.get("name", "장소")
+                tgt_places = day_obj_tgt.setdefault("places", [])
+                tgt_places.append(copy.deepcopy(moved_place))
+
+                yield {"type": "day_update", "data": {**day_obj_src, "day_number": src}}
+                yield {"type": "day_update", "data": {**day_obj_tgt, "day_number": tgt}}
+                yield {
+                    "type": "agent_status",
+                    "data": {"agent": "planner", "status": "done", "message": f"Day {src} → Day {tgt} '{moved_name}' 이동 완료!"},
+                }
+                yield {
+                    "type": "chat_chunk",
+                    "data": {"text": f"Day {src}의 '{moved_name}'을 Day {tgt}로 이동했습니다 (미저장 — 저장 후 영구 보관됩니다)."},
+                }
+                return
+
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "planner", "status": "done", "message": "장소 이동 완료"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": "장소를 이동하려면 먼저 여행 계획을 만들거나 저장해주세요."},
             }
 
     async def _handle_get_weather(

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-07T15:00:00Z (Evolve Run #125)
-Run count: 151
+Last run: 2026-04-07T16:00:00Z (Evolve Run #126)
+Run count: 152
 Phase: Phase 10: Chat + Multi-Agent Dashboard
 Health: GREEN
 Error Budget: HEALTHY
-Tasks completed: 101 (#100 E2E: duplicate_day Playwright scenarios — 2 scenarios: happy path + out-of-range error path)
-Current focus: #101 Chat: move_place intent
-Next planned: #102 Chat: set_day_label intent
+Tasks completed: 102 (#101 Chat: move_place intent — place removed from source, appended to target; day_update SSE for both days; 11 tests)
+Current focus: #102 Chat: set_day_label intent
+Next planned: #103 E2E: message timestamp Playwright scenarios
 
 ## LTES Snapshot
 
 - Latency: ~50000ms (evolve run)
-- Traffic: 29 commits/24h
-- Errors: 0 test failures (1576 passed, 12 skipped), error_rate=0.0%
-- Saturation: 4 tasks ready
+- Traffic: 30 commits/24h
+- Errors: 0 test failures (1587 passed, 12 skipped), error_rate=0.0%
+- Saturation: 3 tasks ready
 
 ## Phase Transition
 
@@ -29,6 +29,15 @@ Next planned: #102 Chat: set_day_label intent
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #126 — 2026-04-07T16:00:00Z
+- **Task**: #101 - Chat: `move_place` intent — move a place from one day to another [feature]
+- **Result**: GREEN ✓ (QA pass)
+- **Tests**: 1587/1587 passed, 12 skipped; 11 new tests added (TestMovePlaceHandler: 9 in-memory + 2 DB integration)
+- **Files changed**: src/app/chat.py (+290/-2), tests/test_chat.py (+11 tests)
+- **Builder note**: move_place supports match by place_index (1-based) or by name (partial case-insensitive). Place row updated in DB (day_itinerary_id) and in-memory (pop from source, append to target). day_update SSE emitted for BOTH source and target days. Error chat_chunk when day out of range or place not found. All done criteria satisfied.
+- **LTES**: L=50000ms T=1 commit E=0 test failures S=3 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✓ → reporter ✓
 
 ### Evolve Run #125 — 2026-04-07T15:00:00Z
 - **Task**: #100 - E2E: `duplicate_day` Playwright scenarios [test]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -7836,3 +7836,358 @@ class TestDuplicateDay:
         finally:
             db.close()
             Base.metadata.drop_all(bind=engine)
+
+
+# Task #101: move_place intent handler
+# done_criteria: "1일차 두 번째 장소를 3일차로 옮겨줘" → place removed from source, appended to target;
+#                day_update SSE for both days; error when day/place not found; 2+ tests
+
+class TestMovePlaceHandler:
+    """_handle_move_place: move a place from source day to target day; emits day_update for both days."""
+
+    def test_move_place_intent_accepted_by_model(self):
+        """Intent model must accept move_place as a valid action."""
+        intent = Intent(
+            action="move_place",
+            day_number=1,
+            day_number_2=3,
+            place_index=2,
+            raw_message="1일차 두 번째 장소를 3일차로 옮겨줘",
+        )
+        assert intent.action == "move_place"
+        assert intent.day_number == 1
+        assert intent.day_number_2 == 3
+        assert intent.place_index == 2
+
+    def test_move_place_activates_planner_agent(self):
+        """move_place must activate the planner agent."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "도쿄",
+            "days": [
+                {"day_number": 1, "date": "2026-05-01", "places": [{"name": "센소지", "category": "sightseeing"}, {"name": "아키하바라", "category": "shopping"}]},
+                {"day_number": 2, "date": "2026-05-02", "places": []},
+                {"day_number": 3, "date": "2026-05-03", "places": []},
+            ],
+        }
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="move_place", day_number=1, day_number_2=3, place_index=2, raw_message="1일차 두 번째 장소를 3일차로 옮겨줘"
+        )):
+            events = _collect_events(svc, session.session_id, "1일차 두 번째 장소를 3일차로 옮겨줘")
+
+        agent_events = [e for e in events if e["type"] == "agent_status" and e["data"]["agent"] == "planner"]
+        assert any(e["data"]["status"] == "working" for e in agent_events)
+
+    def test_move_place_by_index_emits_day_update_for_both_days(self):
+        """move_place by index removes place from source and appends to target; day_update for both."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "도쿄",
+            "days": [
+                {"day_number": 1, "date": "2026-05-01", "places": [
+                    {"name": "센소지", "category": "sightseeing"},
+                    {"name": "아키하바라", "category": "shopping"},
+                ]},
+                {"day_number": 2, "date": "2026-05-02", "places": []},
+                {"day_number": 3, "date": "2026-05-03", "places": [{"name": "신주쿠", "category": "shopping"}]},
+            ],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="move_place", day_number=1, day_number_2=3, place_index=2, raw_message="1일차 두 번째 장소를 3일차로 옮겨줘"
+        )):
+            events = _collect_events(svc, session.session_id, "1일차 두 번째 장소를 3일차로 옮겨줘")
+
+        day_updates = [e for e in events if e["type"] == "day_update"]
+        assert len(day_updates) == 2, "day_update for both source and target"
+
+        day_numbers = {e["data"]["day_number"] for e in day_updates}
+        assert day_numbers == {1, 3}
+
+        # Source day 1: 아키하바라 removed, only 센소지 remains
+        src_update = next(e for e in day_updates if e["data"]["day_number"] == 1)
+        src_names = [p["name"] for p in src_update["data"]["places"]]
+        assert "아키하바라" not in src_names
+        assert "센소지" in src_names
+
+        # Target day 3: 아키하바라 appended
+        tgt_update = next(e for e in day_updates if e["data"]["day_number"] == 3)
+        tgt_names = [p["name"] for p in tgt_update["data"]["places"]]
+        assert "아키하바라" in tgt_names
+        assert "신주쿠" in tgt_names
+
+    def test_move_place_by_name_emits_day_update_for_both_days(self):
+        """move_place by name removes the named place from source and appends to target."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "파리",
+            "days": [
+                {"day_number": 1, "date": "2026-06-01", "places": [
+                    {"name": "루브르 박물관", "category": "museum"},
+                    {"name": "에펠탑", "category": "landmark"},
+                ]},
+                {"day_number": 2, "date": "2026-06-02", "places": []},
+            ],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="move_place", day_number=1, day_number_2=2, query="루브르", raw_message="1일차 루브르를 2일차로 옮겨줘"
+        )):
+            events = _collect_events(svc, session.session_id, "1일차 루브르를 2일차로 옮겨줘")
+
+        day_updates = [e for e in events if e["type"] == "day_update"]
+        assert len(day_updates) == 2
+
+        src_update = next(e for e in day_updates if e["data"]["day_number"] == 1)
+        assert "루브르 박물관" not in [p["name"] for p in src_update["data"]["places"]]
+        assert "에펠탑" in [p["name"] for p in src_update["data"]["places"]]
+
+        tgt_update = next(e for e in day_updates if e["data"]["day_number"] == 2)
+        assert "루브르 박물관" in [p["name"] for p in tgt_update["data"]["places"]]
+
+    def test_move_place_source_place_removed_from_session_last_plan(self):
+        """After move_place, session.last_plan source day must not contain the moved place."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "도쿄",
+            "days": [
+                {"day_number": 1, "date": "2026-05-01", "places": [
+                    {"name": "센소지", "category": "sightseeing"},
+                    {"name": "도쿄 타워", "category": "landmark"},
+                ]},
+                {"day_number": 2, "date": "2026-05-02", "places": []},
+            ],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="move_place", day_number=1, day_number_2=2, place_index=1, raw_message="1일차 첫 번째 장소를 2일차로 옮겨줘"
+        )):
+            _collect_events(svc, session.session_id, "1일차 첫 번째 장소를 2일차로 옮겨줘")
+
+        src_places = session.last_plan["days"][0]["places"]
+        tgt_places = session.last_plan["days"][1]["places"]
+        assert len(src_places) == 1
+        assert src_places[0]["name"] == "도쿄 타워"
+        assert any(p["name"] == "센소지" for p in tgt_places)
+
+    def test_move_place_out_of_range_day_emits_error(self):
+        """move_place with out-of-range target day emits error chat_chunk, no day_update."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "도쿄",
+            "days": [
+                {"day_number": 1, "date": "2026-05-01", "places": [{"name": "센소지", "category": "sightseeing"}]},
+                {"day_number": 2, "date": "2026-05-02", "places": []},
+            ],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="move_place", day_number=1, day_number_2=5, place_index=1, raw_message="1일차 첫 번째 장소를 5일차로 옮겨줘"
+        )):
+            events = _collect_events(svc, session.session_id, "1일차 첫 번째 장소를 5일차로 옮겨줘")
+
+        day_updates = [e for e in events if e["type"] == "day_update"]
+        assert len(day_updates) == 0
+
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        assert len(chat_chunks) >= 1
+        assert any("5" in e["data"]["text"] for e in chat_chunks)
+
+    def test_move_place_place_not_found_emits_error(self):
+        """move_place when the named place is not in source day emits error chat_chunk."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "도쿄",
+            "days": [
+                {"day_number": 1, "date": "2026-05-01", "places": [{"name": "센소지", "category": "sightseeing"}]},
+                {"day_number": 2, "date": "2026-05-02", "places": []},
+            ],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="move_place", day_number=1, day_number_2=2, query="없는장소", raw_message="1일차 없는장소를 2일차로 이동해줘"
+        )):
+            events = _collect_events(svc, session.session_id, "1일차 없는장소를 2일차로 이동해줘")
+
+        day_updates = [e for e in events if e["type"] == "day_update"]
+        assert len(day_updates) == 0
+
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        assert any("없는장소" in e["data"]["text"] for e in chat_chunks)
+
+    def test_move_place_no_plan_emits_chat_chunk(self):
+        """move_place with no plan returns a helpful message."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="move_place", day_number=1, day_number_2=2, place_index=1, raw_message="1일차 첫 번째 장소를 2일차로 옮겨줘"
+        )):
+            events = _collect_events(svc, session.session_id, "1일차 첫 번째 장소를 2일차로 옮겨줘")
+
+        day_updates = [e for e in events if e["type"] == "day_update"]
+        assert len(day_updates) == 0
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        assert len(chat_chunks) >= 1
+
+    def test_move_place_missing_day_numbers_emits_error(self):
+        """move_place without source or target day emits instructional chat_chunk."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="move_place", raw_message="장소 이동해줘"
+        )):
+            events = _collect_events(svc, session.session_id, "장소 이동해줘")
+
+        day_updates = [e for e in events if e["type"] == "day_update"]
+        assert len(day_updates) == 0
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        assert len(chat_chunks) >= 1
+
+    def test_move_place_db_moves_place_and_emits_day_update_for_both(self):
+        """move_place with saved plan updates Place's day_itinerary_id and emits day_update for both days."""
+        from app.database import Base
+        from app.models import (
+            DayItinerary as DayItineraryModel,
+            Place as PlaceModel,
+            TravelPlan as TravelPlanModel,
+        )
+        from datetime import date as date_type
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan = TravelPlanModel(
+                destination="도쿄",
+                start_date=date_type(2026, 5, 1),
+                end_date=date_type(2026, 5, 3),
+                budget=2000000.0,
+                interests="",
+                status="draft",
+            )
+            db.add(plan)
+            db.commit()
+            db.refresh(plan)
+
+            day1 = DayItineraryModel(travel_plan_id=plan.id, date=date_type(2026, 5, 1), notes="")
+            day2 = DayItineraryModel(travel_plan_id=plan.id, date=date_type(2026, 5, 2), notes="")
+            day3 = DayItineraryModel(travel_plan_id=plan.id, date=date_type(2026, 5, 3), notes="")
+            db.add_all([day1, day2, day3])
+            db.commit()
+            db.refresh(day1)
+            db.refresh(day2)
+            db.refresh(day3)
+
+            # Source: day1 has 2 places
+            p1 = PlaceModel(day_itinerary_id=day1.id, name="센소지", category="sightseeing", estimated_cost=0.0, order=0)
+            p2 = PlaceModel(day_itinerary_id=day1.id, name="아키하바라", category="shopping", estimated_cost=0.0, order=1)
+            # Target: day3 has 1 place
+            p3 = PlaceModel(day_itinerary_id=day3.id, name="신주쿠", category="shopping", estimated_cost=0.0, order=0)
+            db.add_all([p1, p2, p3])
+            db.commit()
+
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_saved_plan_id = plan.id
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="move_place", day_number=1, day_number_2=3, place_index=2, raw_message="1일차 두 번째 장소를 3일차로 옮겨줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "1일차 두 번째 장소를 3일차로 옮겨줘", db)
+
+            db.expire_all()
+
+            # day1 must no longer contain 아키하바라
+            places_in_day1 = db.query(PlaceModel).filter(PlaceModel.day_itinerary_id == day1.id).all()
+            names_in_day1 = {p.name for p in places_in_day1}
+            assert "아키하바라" not in names_in_day1
+            assert "센소지" in names_in_day1
+
+            # day3 must contain 아키하바라 appended after existing places
+            places_in_day3 = db.query(PlaceModel).filter(PlaceModel.day_itinerary_id == day3.id).all()
+            names_in_day3 = {p.name for p in places_in_day3}
+            assert "아키하바라" in names_in_day3
+            assert "신주쿠" in names_in_day3
+
+            # day_update emitted for BOTH source and target
+            day_updates = [e for e in events if e["type"] == "day_update"]
+            assert len(day_updates) == 2
+
+            day_numbers_updated = {e["data"]["day_number"] for e in day_updates}
+            assert day_numbers_updated == {1, 3}
+
+            src_upd = next(e for e in day_updates if e["data"]["day_number"] == 1)
+            assert "아키하바라" not in [p["name"] for p in src_upd["data"]["places"]]
+
+            tgt_upd = next(e for e in day_updates if e["data"]["day_number"] == 3)
+            tgt_names = [p["name"] for p in tgt_upd["data"]["places"]]
+            assert "아키하바라" in tgt_names
+            assert "신주쿠" in tgt_names
+
+            # Confirm chat_chunk
+            chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+            assert any("아키하바라" in e["data"]["text"] for e in chat_chunks)
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)
+
+    def test_move_place_db_place_not_found_emits_error(self):
+        """move_place with saved plan when place not found emits error, no day_update."""
+        from app.database import Base
+        from app.models import (
+            DayItinerary as DayItineraryModel,
+            Place as PlaceModel,
+            TravelPlan as TravelPlanModel,
+        )
+        from datetime import date as date_type
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan = TravelPlanModel(
+                destination="파리",
+                start_date=date_type(2026, 6, 1),
+                end_date=date_type(2026, 6, 2),
+                budget=1500000.0,
+                interests="",
+                status="draft",
+            )
+            db.add(plan)
+            db.commit()
+            db.refresh(plan)
+
+            day1 = DayItineraryModel(travel_plan_id=plan.id, date=date_type(2026, 6, 1), notes="")
+            day2 = DayItineraryModel(travel_plan_id=plan.id, date=date_type(2026, 6, 2), notes="")
+            db.add_all([day1, day2])
+            db.commit()
+            db.refresh(day1)
+            db.refresh(day2)
+
+            p1 = PlaceModel(day_itinerary_id=day1.id, name="루브르 박물관", category="museum", estimated_cost=0.0, order=0)
+            db.add(p1)
+            db.commit()
+
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_saved_plan_id = plan.id
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="move_place", day_number=1, day_number_2=2, query="없는장소", raw_message="1일차 없는장소를 2일차로 이동"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "1일차 없는장소를 2일차로 이동", db)
+
+            day_updates = [e for e in events if e["type"] == "day_update"]
+            assert len(day_updates) == 0
+
+            chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+            assert any("없는장소" in e["data"]["text"] for e in chat_chunks)
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)


### PR DESCRIPTION
## Evolve Run #126
- **Phase**: Phase 10 (Chat + Multi-Agent Dashboard)
- **Health**: GREEN
- **Task**: #101 - Chat: move_place intent — move a place from one day to another
- **QA**: pass
- **Tests**: 1587/1587 passed, 12 skipped

Closes #139

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #101 move_place; health GREEN; no architect needed |
| 📐 Architect | ⏭️ | Skipped (backlog_ready_count=3 ≥ 2) |
| 🔨 Builder | ✅ | src/app/chat.py (+290/-2), tests/test_chat.py (+11 tests) |
| 🧪 QA | ✅ | 1587/1587 pass; all checks pass (tests, lint, done_criteria, integration_quality, no_regressions) |
| 📝 Reporter | ✅ | This PR |

### Implementation Summary
- `move_place` intent handler added to `chat.py`
- Supports match by place_index (1-based) or name (partial case-insensitive)
- DB path: updates `Place.day_itinerary_id`; in-memory path: pops from source, appends to target
- `day_update` SSE emitted for BOTH source and target days
- Error `chat_chunk` when day out of range or place not found
- 11 tests: 9 in-memory + 2 DB integration tests

🤖 Auto-generated by Evolve Pipeline