### PR TITLE
feature: #102 Chat set_day_label intent — set a custom title/label for a day (#102)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -12,12 +12,6 @@ _(없음)_
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
 
-- [ ] #102 - Chat: `set_day_label` intent — set a custom title/label for a day [feature]
-  - ref: markdowns/feat-chat-dashboard.md
-  - files: src/app/chat.py, src/app/schemas.py, tests/test_chat.py
-  - done: "1일차 이름을 '미식 투어'로 해줘" → DayItinerary.label persisted; day_update SSE with label; DayItineraryOut includes label; 2+ tests
-  - gh: #140
-
 - [ ] #103 - E2E: message timestamp Playwright scenarios [test]
   - ref: markdowns/feat-chat-dashboard.md
   - depends: #95
@@ -151,6 +145,7 @@ _(없음)_
 - [x] #96 - Chat: `duplicate_day` intent — copy a day's itinerary to another day [feature] — 2026-04-07
 - [x] #100 - E2E: `duplicate_day` Playwright scenarios [test] — 2026-04-07
 - [x] #101 - Chat: `move_place` intent — move a place from one day to another [feature] — 2026-04-07
+- [x] #102 - Chat: `set_day_label` intent — set a custom title/label for a day [feature] — 2026-04-07
 
 ### Phase 9: User Experience & Polish (remaining, completed)
 - [x] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature] — 2026-04-04
@@ -163,5 +158,5 @@ _(없음)_
 ## Metrics
 
 - Velocity: 1 task/run
-- Total tasks: 102 done, 3 ready (0 in progress)
+- Total tasks: 103 done, 2 ready (0 in progress)
 - Phase: 10 (Chat + Multi-Agent Dashboard)

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,11 +1,11 @@
 {
-  "last_updated": "2026-04-07T16:10:00Z",
+  "last_updated": "2026-04-07T17:00:00Z",
   "summary": {
-    "total_runs": 153,
-    "total_commits": 164,
-    "total_tests": 1587,
-    "tasks_completed": 102,
-    "tasks_remaining": 3,
+    "total_runs": 154,
+    "total_commits": 165,
+    "total_tests": 1598,
+    "tasks_completed": 103,
+    "tasks_remaining": 2,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
     "health": "GREEN"
   },
@@ -66,11 +66,11 @@
     },
     {
       "date": "2026-04-07",
-      "runs": 8,
-      "tasks_completed": 5,
-      "tests_passed": 1587,
+      "runs": 9,
+      "tasks_completed": 6,
+      "tests_passed": 1598,
       "tests_failed": 0,
-      "commits": 30,
+      "commits": 31,
       "health": "GREEN"
     }
   ],
@@ -87,10 +87,10 @@
     "health": "GREEN"
   },
   "last_evolve": {
-    "timestamp": "2026-04-07T16:00:00Z",
-    "run_id": "2026-04-07-1600",
-    "task": "#101 - Chat: move_place intent — move a place from one day to another",
-    "tests_passed": 1587,
+    "timestamp": "2026-04-07T17:00:00Z",
+    "run_id": "2026-04-07-1700",
+    "task": "#102 - Chat: set_day_label intent — set a custom title/label for a day",
+    "tests_passed": 1598,
     "tests_failed": 0,
     "health": "GREEN",
     "qa_verdict": "pass"

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,8 +7,8 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 153,
-    "successful_runs": 147,
+    "total_runs": 154,
+    "successful_runs": 148,
     "failed_runs": 1,
     "success_rate": 0.961,
     "budget_remaining": 0.95,
@@ -653,6 +653,13 @@
   ],
   "consecutive_qa_failures": 0,
   "history_tail": {
+    "run_id": "2026-04-07-1700",
+    "task": "#102 - Chat: set_day_label intent — set a custom title/label for a day",
+    "result": "success",
+    "tests_passed": 1598,
+    "tests_total": 1610
+  },
+  "history_tail_prev2_prev": {
     "run_id": "2026-04-07-1600",
     "task": "#101 - Chat: move_place intent — move a place from one day to another",
     "result": "success",

--- a/observability/logs/2026-04-07/run-17-00.json
+++ b/observability/logs/2026-04-07/run-17-00.json
@@ -1,0 +1,61 @@
+{
+  "trace": {
+    "run_id": "2026-04-07-1700",
+    "timestamp": "2026-04-07T17:00:00Z",
+    "phase": "Phase 10",
+    "health": "GREEN",
+    "task": "#102 - Chat: set_day_label intent — set a custom title/label for a day",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "pass",
+      "reporter": "completed"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #102 set_day_label; health GREEN; architect skipped (backlog_ready_count=3 >= 2)"
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "backlog_ready_count=3 >= 2, no architect run needed"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "DayItinerary.label (VARCHAR 200, nullable) added; SQLite migration via ALTER TABLE; DayItineraryBase/Out schema gains Optional[str] label; set_day_label intent handler with DB + in-memory paths; SSE day_update with label; 11 new tests; 215 lines added"
+    },
+    {
+      "agent": "qa",
+      "status": "pass",
+      "detail": "1598 passed, 12 skipped; all checks pass: tests, new_tests_exist, lint, done_criteria, no_regressions, integration_test_quality, e2e_integration, no_secrets_leaked"
+    },
+    {
+      "agent": "reporter",
+      "status": "completed",
+      "detail": "LTES log, status.md, backlog.md, error-budget.json, dashboard.json updated; PR created with label evolve; Issue #140 closed"
+    }
+  ],
+  "ltes": {
+    "latency": {
+      "total_duration_ms": 50000
+    },
+    "traffic": {
+      "commits": 1,
+      "lines_added": 215,
+      "lines_removed": 2,
+      "files_changed": 5
+    },
+    "errors": {
+      "test_failures": 0,
+      "fix_attempts": 0
+    },
+    "saturation": {
+      "backlog_remaining": 2
+    }
+  }
+}

--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -35,7 +35,7 @@ _DEFAULT_DEPARTURE = "서울(ICN)"  # default origin for flight search
 
 
 class Intent(BaseModel):
-    action: str  # create_plan | confirm_plan | modify_day | refine_plan | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | delete_plan | view_plan | add_expense | update_expense | update_plan | get_expense_summary | delete_expense | list_expenses | copy_plan | get_weather | reset_conversation | add_day_note | suggest_improvements | remove_place | add_place | share_plan | reorder_days | clear_day | duplicate_day | move_place | general
+    action: str  # create_plan | confirm_plan | modify_day | refine_plan | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | delete_plan | view_plan | add_expense | update_expense | update_plan | get_expense_summary | delete_expense | list_expenses | copy_plan | get_weather | reset_conversation | add_day_note | suggest_improvements | remove_place | add_place | share_plan | reorder_days | clear_day | duplicate_day | move_place | set_day_label | general
     destination: Optional[str] = None
     start_date: Optional[str] = None
     end_date: Optional[str] = None
@@ -188,7 +188,7 @@ The user is based in South Korea. Budget values should be in KRW (Korean Won). D
 User message: "{message}"
 
 Return a JSON object with these fields:
-- action: one of "create_plan", "confirm_plan", "modify_day", "refine_plan", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "add_expense", "update_expense", "update_plan", "get_expense_summary", "delete_expense", "list_expenses", "copy_plan", "get_weather", "reset_conversation", "add_day_note", "suggest_improvements", "remove_place", "add_place", "share_plan", "reorder_days", "clear_day", "duplicate_day", "move_place", "general"
+- action: one of "create_plan", "confirm_plan", "modify_day", "refine_plan", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "add_expense", "update_expense", "update_plan", "get_expense_summary", "delete_expense", "list_expenses", "copy_plan", "get_weather", "reset_conversation", "add_day_note", "suggest_improvements", "remove_place", "add_place", "share_plan", "reorder_days", "clear_day", "duplicate_day", "move_place", "set_day_label", "general"
 - Use action "confirm_plan" when the user confirms they want to proceed with creating a travel plan (e.g. "네 세워줘", "좋아 계획해줘", "응 진행해", "yes please", "go ahead", "확인")
 - IMPORTANT: Use action "general" for casual conversation, questions, opinions, or when the user is discussing/exploring options but NOT explicitly requesting to create or modify a plan. Examples: "후쿠오카 4박 5일은 너무 길지 않을까?" → general (asking opinion), "여행지 추천해줘" → general (asking for suggestions), "벌레 싫은데" → general (sharing preference)
 - Use "create_plan" ONLY when the user explicitly asks to CREATE a plan with specific details. Use "refine_plan" ONLY when the user explicitly asks to CHANGE an existing plan (e.g. "일정 수정해줘", "3일차 바꿔줘")
@@ -221,6 +221,7 @@ Return a JSON object with these fields:
 - Use action "clear_day" when user wants to remove ALL places from a specific day (e.g. "3일차 일정 다 지워줘", "Day 2 일정 전부 삭제", "2일차 장소 모두 제거", "clear all places from day 3", "day 1 일정 비워줘"); set day_number to the referenced day
 - Use action "duplicate_day" when user wants to copy all places from one day to another day (e.g. "2일차 일정을 4일차에도 넣어줘", "1일차 복사해서 3일차에 붙여줘", "Day 2 일정을 Day 4로 복사", "copy day 1 to day 3", "2일차랑 똑같이 4일차도 만들어줘"); set day_number to the SOURCE day and day_number_2 to the TARGET day
 - Use action "move_place" when user wants to move/transfer a specific place from one day to another day (e.g. "1일차 두 번째 장소를 3일차로 옮겨줘", "Day 2에서 센소지를 Day 4로 이동해줘", "3일차 첫 번째 장소를 1일차로 옮겨", "move place from day 1 to day 3", "2일차 루브르를 3일차로 이동"); set day_number to the SOURCE day, day_number_2 to the TARGET day, query to the place name if mentioned, and place_index to the 1-based position if an ordinal is mentioned (e.g. "첫 번째" → 1, "두 번째" → 2, "마지막" → -1)
+- Use action "set_day_label" when user wants to give a custom title/label/name to a specific day (e.g. "1일차 이름을 '미식 투어'로 해줘", "Day 2 제목을 '자연 탐방'으로 설정해줘", "3일차 이름 바꿔줘, '쇼핑 데이'로", "set day 1 label to 'Food Tour'", "name day 3 'Beach Day'", "Day 2 타이틀을 '박물관 투어'로 해줘"); set day_number to the referenced day and query to the label text
 - raw_message: the exact original message"""
 
             client = genai.Client(api_key=self._api_key)
@@ -420,6 +421,9 @@ Return a JSON object with these fields:
                 yield _track_and_collect(event)
         elif intent.action == "move_place":
             async for event in self._handle_move_place(intent, session, db):
+                yield _track_and_collect(event)
+        elif intent.action == "set_day_label":
+            async for event in self._handle_set_day_label(intent, session, db):
                 yield _track_and_collect(event)
         else:  # general
             async for event in self._handle_general(intent, session):
@@ -4146,6 +4150,180 @@ Return a JSON object with these fields:
             "type": "chat_chunk",
             "data": {"text": "대화 내역을 초기화했습니다. 새로운 여행 계획을 시작해보세요!"},
         }
+
+
+    async def _handle_set_day_label(
+        self,
+        intent: Intent,
+        session: "ChatSession",
+        db: Optional["Session"] = None,
+    ) -> AsyncGenerator[dict, None]:
+        """Set a custom title/label for a specific day.
+
+        Reads day_number and query (the label text) from intent.
+        Persists label to DayItinerary.label in DB (if available), and updates
+        session.last_plan for in-memory state. Emits day_update with the new label.
+        """
+        day_number = intent.day_number
+        new_label = (intent.query or "").strip()
+
+        yield {
+            "type": "agent_status",
+            "data": {"agent": "planner", "status": "working", "message": f"Day {day_number} 레이블 설정 중..."},
+        }
+        await asyncio.sleep(0)
+
+        if not day_number:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "planner", "status": "error", "message": "날짜를 지정해주세요"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": "어떤 날짜의 이름을 바꿀지 알려주세요 (예: '1일차 이름을 미식 투어로 해줘')."},
+            }
+            return
+
+        if not new_label:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "planner", "status": "error", "message": "레이블 텍스트가 없습니다"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": "설정할 이름/제목을 알려주세요 (예: '1일차 이름을 미식 투어로 해줘')."},
+            }
+            return
+
+        plan_id: Optional[int] = intent.plan_id or session.last_saved_plan_id
+
+        if db is not None and plan_id is not None:
+            try:
+                from app.models import (
+                    DayItinerary as DayItineraryModel,
+                    TravelPlan as TravelPlanModel,
+                )
+
+                plan = db.get(TravelPlanModel, plan_id)
+                if plan is None:
+                    yield {
+                        "type": "agent_status",
+                        "data": {"agent": "planner", "status": "error", "message": f"계획 #{plan_id}을 찾을 수 없습니다"},
+                    }
+                    yield {
+                        "type": "chat_chunk",
+                        "data": {"text": f"계획 #{plan_id}을 찾을 수 없습니다."},
+                    }
+                    return
+
+                days = (
+                    db.query(DayItineraryModel)
+                    .filter(DayItineraryModel.travel_plan_id == plan_id)
+                    .order_by(DayItineraryModel.date)
+                    .all()
+                )
+
+                day_idx = day_number - 1
+                if not days or day_idx < 0 or day_idx >= len(days):
+                    yield {
+                        "type": "agent_status",
+                        "data": {"agent": "planner", "status": "error", "message": f"Day {day_number}을 찾을 수 없습니다"},
+                    }
+                    yield {
+                        "type": "chat_chunk",
+                        "data": {"text": f"계획에 Day {day_number}이 없습니다 (총 {len(days)}일)."},
+                    }
+                    return
+
+                day_obj = days[day_idx]
+                day_obj.label = new_label
+                db.commit()
+                db.refresh(day_obj)
+
+                places_data = [
+                    {
+                        "name": p.name,
+                        "category": p.category,
+                        "address": p.address,
+                        "estimated_cost": p.estimated_cost,
+                        "ai_reason": p.ai_reason,
+                        "order": p.order,
+                    }
+                    for p in sorted(day_obj.places, key=lambda x: x.order)
+                ]
+
+                yield {
+                    "type": "day_update",
+                    "data": {
+                        "day_number": day_number,
+                        "date": day_obj.date.isoformat(),
+                        "notes": day_obj.notes,
+                        "transport": day_obj.transport,
+                        "label": day_obj.label,
+                        "places": places_data,
+                    },
+                }
+                yield {
+                    "type": "agent_status",
+                    "data": {"agent": "planner", "status": "done", "message": f"Day {day_number} 레이블 '{new_label}' 설정 완료!"},
+                }
+                yield {
+                    "type": "chat_chunk",
+                    "data": {"text": f"Day {day_number}의 이름을 '{new_label}'으로 설정했습니다."},
+                }
+
+            except Exception as exc:
+                logger.error("_handle_set_day_label: failed — %s: %s", type(exc).__name__, exc, exc_info=True)
+                yield {
+                    "type": "agent_status",
+                    "data": {"agent": "planner", "status": "error", "message": "레이블 설정 실패"},
+                }
+                yield {
+                    "type": "chat_chunk",
+                    "data": {"text": f"레이블 설정 중 오류가 발생했습니다: {exc}"},
+                }
+        else:
+            # In-memory plan
+            last_plan = session.last_plan
+            if last_plan:
+                days = last_plan.get("days", [])
+                day_idx = day_number - 1
+                if day_idx < 0 or day_idx >= len(days):
+                    yield {
+                        "type": "agent_status",
+                        "data": {"agent": "planner", "status": "error", "message": f"Day {day_number}이 범위를 벗어났습니다"},
+                    }
+                    yield {
+                        "type": "chat_chunk",
+                        "data": {"text": f"Day {day_number}은 이 계획에 없습니다 (총 {len(days)}일)."},
+                    }
+                    return
+
+                day_obj = days[day_idx]
+                day_obj["label"] = new_label
+
+                yield {
+                    "type": "day_update",
+                    "data": {**day_obj, "day_number": day_number, "label": new_label},
+                }
+                yield {
+                    "type": "agent_status",
+                    "data": {"agent": "planner", "status": "done", "message": f"Day {day_number} 레이블 '{new_label}' 설정 완료!"},
+                }
+                yield {
+                    "type": "chat_chunk",
+                    "data": {"text": f"Day {day_number}의 이름을 '{new_label}'으로 설정했습니다 (미저장 — 저장 후 영구 보관됩니다)."},
+                }
+                return
+
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "planner", "status": "error", "message": "레이블을 설정할 계획이 없습니다"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": "레이블을 설정하려면 먼저 여행 계획을 만들거나 저장해주세요."},
+            }
 
 
 # Module-level singleton used by the chat router

--- a/src/app/database.py
+++ b/src/app/database.py
@@ -25,3 +25,19 @@ def get_db():
 
 def init_db():
     Base.metadata.create_all(bind=engine)
+    _apply_migrations()
+
+
+def _apply_migrations():
+    """Apply incremental schema changes that create_all cannot handle (existing tables)."""
+    with engine.connect() as conn:
+        # #102: add label column to day_itineraries
+        try:
+            conn.execute(
+                __import__("sqlalchemy").text(
+                    "ALTER TABLE day_itineraries ADD COLUMN label VARCHAR(200)"
+                )
+            )
+            conn.commit()
+        except Exception:
+            pass  # column already exists — ignore

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -53,6 +53,7 @@ class DayItinerary(Base):
     date: Mapped[date] = mapped_column(Date, nullable=False)
     notes: Mapped[str] = mapped_column(Text, default="")
     transport: Mapped[str] = mapped_column(String(100), default="")
+    label: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
 
     travel_plan: Mapped["TravelPlan"] = relationship(
         "TravelPlan", back_populates="itineraries"

--- a/src/app/schemas.py
+++ b/src/app/schemas.py
@@ -52,6 +52,7 @@ class DayItineraryBase(BaseModel):
     date: date
     notes: str = ""
     transport: str = ""
+    label: Optional[str] = None
 
 
 class DayItineraryCreate(DayItineraryBase):

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-07T16:10:00Z (Monitor Run #135)
-Run count: 153
+Last run: 2026-04-07T17:00:00Z (Evolve Run #127)
+Run count: 154
 Phase: Phase 10: Chat + Multi-Agent Dashboard
 Health: GREEN
 Error Budget: HEALTHY
-Tasks completed: 102 (#101 Chat: move_place intent — place removed from source, appended to target; day_update SSE for both days; 11 tests)
-Current focus: #102 Chat: set_day_label intent
-Next planned: #103 E2E: message timestamp Playwright scenarios
+Tasks completed: 103 (#102 Chat: set_day_label intent — DayItinerary.label persisted; day_update SSE with label; DayItineraryOut includes label; 11 tests)
+Current focus: #103 E2E: message timestamp Playwright scenarios
+Next planned: #104 Chat: quick_summary intent
 
 ## LTES Snapshot
 
-- Latency: ~57000ms (monitor run)
-- Traffic: 30 commits/24h
-- Errors: 0 test failures (1587 passed, 12 skipped), error_rate=0.0%
-- Saturation: 3 tasks ready
+- Latency: ~50000ms (evolve run)
+- Traffic: 31 commits/24h
+- Errors: 0 test failures (1598 passed, 12 skipped), error_rate=0.0%
+- Saturation: 2 tasks ready
 
 ## Phase Transition
 
@@ -29,6 +29,15 @@ Next planned: #103 E2E: message timestamp Playwright scenarios
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #127 — 2026-04-07T17:00:00Z
+- **Task**: #102 - Chat: `set_day_label` intent — set a custom title/label for a day [feature]
+- **Result**: GREEN ✓ (QA pass)
+- **Tests**: 1598/1598 passed, 12 skipped; 11 new tests added (TestSetDayLabelHandler: intent acceptance, in-memory label set, DB persistence, error paths — missing day_number, missing label, no plan, out-of-range for both in-memory and DB paths, schema validation)
+- **Files changed**: src/app/models.py, src/app/schemas.py, src/app/database.py, src/app/chat.py, tests/test_chat.py (+215/-2)
+- **Builder note**: DayItinerary.label (VARCHAR 200, nullable) added to model; SQLite migration via ALTER TABLE in _apply_migrations(). DayItineraryBase/Out gains Optional[str] label. ChatService: intent + system prompt updated; _handle_set_day_label covers DB path (persists, emits day_update with label) and in-memory path (mutates session.last_plan, emits day_update). Error paths: missing day_number, missing label text, out-of-range day, no plan.
+- **LTES**: L=50000ms T=1 commit E=0 test failures S=2 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✓ → reporter ✓
 
 ### Monitor Run #135 — 2026-04-07T16:10:00Z
 - **Task**: monitor

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -8191,3 +8191,266 @@ class TestMovePlaceHandler:
         finally:
             db.close()
             Base.metadata.drop_all(bind=engine)
+
+
+# ---------------------------------------------------------------------------
+# Task #102: set_day_label intent — set a custom title/label for a day
+# ---------------------------------------------------------------------------
+
+class TestSetDayLabelHandler:
+    """_handle_set_day_label: persist label on DayItinerary; emit day_update with label."""
+
+    def test_set_day_label_intent_accepted_by_model(self):
+        """Intent model must accept set_day_label as a valid action."""
+        intent = Intent(
+            action="set_day_label",
+            day_number=1,
+            query="미식 투어",
+            raw_message="1일차 이름을 '미식 투어'로 해줘",
+        )
+        assert intent.action == "set_day_label"
+        assert intent.day_number == 1
+        assert intent.query == "미식 투어"
+
+    def test_set_day_label_in_memory_emits_day_update_with_label(self):
+        """set_day_label updates session.last_plan day label and emits day_update."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "도쿄",
+            "days": [
+                {"day_number": 1, "date": "2026-05-01", "places": [{"name": "센소지"}]},
+                {"day_number": 2, "date": "2026-05-02", "places": []},
+            ],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="set_day_label", day_number=1, query="미식 투어", raw_message="1일차 이름을 '미식 투어'로 해줘"
+        )):
+            events = _collect_events(svc, session.session_id, "1일차 이름을 '미식 투어'로 해줘")
+
+        day_updates = [e for e in events if e["type"] == "day_update"]
+        assert len(day_updates) == 1
+        assert day_updates[0]["data"]["label"] == "미식 투어"
+        assert day_updates[0]["data"]["day_number"] == 1
+
+        # session.last_plan should be mutated
+        assert session.last_plan["days"][0].get("label") == "미식 투어"
+
+    def test_set_day_label_in_memory_emits_agent_done(self):
+        """set_day_label emits planner agent done status."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "파리",
+            "days": [{"day_number": 1, "date": "2026-06-01", "places": []}],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="set_day_label", day_number=1, query="박물관 투어", raw_message="1일차 이름 박물관 투어"
+        )):
+            events = _collect_events(svc, session.session_id, "1일차 이름 박물관 투어")
+
+        agent_events = [e for e in events if e["type"] == "agent_status" and e["data"]["agent"] == "planner"]
+        assert any(e["data"]["status"] == "done" for e in agent_events)
+
+    def test_set_day_label_missing_day_number_emits_error(self):
+        """set_day_label without day_number emits instructional chat_chunk."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="set_day_label", day_number=None, query="미식 투어", raw_message="이름을 미식 투어로 해줘"
+        )):
+            events = _collect_events(svc, session.session_id, "이름을 미식 투어로 해줘")
+
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        assert len(chat_chunks) >= 1
+        assert any("날짜" in e["data"]["text"] for e in chat_chunks)
+
+    def test_set_day_label_missing_label_text_emits_error(self):
+        """set_day_label without query (label text) emits instructional chat_chunk."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="set_day_label", day_number=1, query="", raw_message="1일차 이름 바꿔줘"
+        )):
+            events = _collect_events(svc, session.session_id, "1일차 이름 바꿔줘")
+
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        assert len(chat_chunks) >= 1
+        text = " ".join(e["data"]["text"] for e in chat_chunks)
+        assert "이름" in text or "제목" in text or "설정" in text
+
+    def test_set_day_label_no_plan_emits_chat_chunk(self):
+        """set_day_label with no plan returns a helpful message."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="set_day_label", day_number=1, query="미식 투어", raw_message="1일차 이름을 미식 투어로 해줘"
+        )):
+            events = _collect_events(svc, session.session_id, "1일차 이름을 미식 투어로 해줘")
+
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        assert len(chat_chunks) >= 1
+        text = " ".join(e["data"]["text"] for e in chat_chunks)
+        assert "계획" in text
+
+    def test_set_day_label_out_of_range_emits_error(self):
+        """set_day_label with out-of-range day emits error chat_chunk, no day_update."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "도쿄",
+            "days": [{"day_number": 1, "date": "2026-05-01", "places": []}],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="set_day_label", day_number=5, query="미식 투어", raw_message="5일차 이름을 미식 투어로 해줘"
+        )):
+            events = _collect_events(svc, session.session_id, "5일차 이름을 미식 투어로 해줘")
+
+        day_updates = [e for e in events if e["type"] == "day_update"]
+        assert len(day_updates) == 0
+
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        assert len(chat_chunks) >= 1
+        assert any("5" in e["data"]["text"] for e in chat_chunks)
+
+    def test_set_day_label_db_persists_label_and_emits_day_update(self):
+        """set_day_label with saved plan persists label in DB and emits day_update with label."""
+        from app.database import Base
+        from app.models import (
+            DayItinerary as DayItineraryModel,
+            TravelPlan as TravelPlanModel,
+        )
+        from datetime import date as date_type
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan = TravelPlanModel(
+                destination="도쿄",
+                start_date=date_type(2026, 5, 1),
+                end_date=date_type(2026, 5, 3),
+                budget=2000000.0,
+                interests="food",
+                status="draft",
+            )
+            db.add(plan)
+            db.commit()
+            db.refresh(plan)
+
+            day1 = DayItineraryModel(travel_plan_id=plan.id, date=date_type(2026, 5, 1), notes="")
+            day2 = DayItineraryModel(travel_plan_id=plan.id, date=date_type(2026, 5, 2), notes="")
+            day3 = DayItineraryModel(travel_plan_id=plan.id, date=date_type(2026, 5, 3), notes="")
+            db.add_all([day1, day2, day3])
+            db.commit()
+            for d in [day1, day2, day3]:
+                db.refresh(d)
+
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_saved_plan_id = plan.id
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="set_day_label", day_number=1, query="미식 투어", raw_message="1일차 이름을 '미식 투어'로 해줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "1일차 이름을 '미식 투어'로 해줘", db)
+
+            # Verify event
+            day_updates = [e for e in events if e["type"] == "day_update"]
+            assert len(day_updates) == 1
+            assert day_updates[0]["data"]["label"] == "미식 투어"
+            assert day_updates[0]["data"]["day_number"] == 1
+
+            # Verify DB persistence
+            db.refresh(day1)
+            assert day1.label == "미식 투어"
+
+            chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+            assert any("미식 투어" in e["data"]["text"] for e in chat_chunks)
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)
+
+    def test_set_day_label_db_out_of_range_emits_error(self):
+        """set_day_label with out-of-range day in DB path emits error, no day_update."""
+        from app.database import Base
+        from app.models import (
+            DayItinerary as DayItineraryModel,
+            TravelPlan as TravelPlanModel,
+        )
+        from datetime import date as date_type
+
+        engine, TestingSession = _make_test_db()
+        db = TestingSession()
+        try:
+            plan = TravelPlanModel(
+                destination="파리",
+                start_date=date_type(2026, 6, 1),
+                end_date=date_type(2026, 6, 2),
+                budget=1500000.0,
+                interests="",
+                status="draft",
+            )
+            db.add(plan)
+            db.commit()
+            db.refresh(plan)
+
+            day1 = DayItineraryModel(travel_plan_id=plan.id, date=date_type(2026, 6, 1), notes="")
+            day2 = DayItineraryModel(travel_plan_id=plan.id, date=date_type(2026, 6, 2), notes="")
+            db.add_all([day1, day2])
+            db.commit()
+
+            svc = _make_service_no_api()
+            session = svc.create_session()
+            session.last_saved_plan_id = plan.id
+
+            with patch.object(svc, "extract_intent", return_value=Intent(
+                action="set_day_label", day_number=5, query="미식 투어", raw_message="5일차 이름을 미식 투어로 해줘"
+            )):
+                events = _collect_events_with_db(svc, session.session_id, "5일차 이름을 미식 투어로 해줘", db)
+
+            day_updates = [e for e in events if e["type"] == "day_update"]
+            assert len(day_updates) == 0
+
+            chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+            assert len(chat_chunks) >= 1
+            assert any("5" in e["data"]["text"] for e in chat_chunks)
+        finally:
+            db.close()
+            Base.metadata.drop_all(bind=engine)
+
+    def test_set_day_label_day_update_includes_label_in_schema(self):
+        """DayItineraryOut schema includes label field."""
+        from app.schemas import DayItineraryOut
+        from datetime import date as date_type
+
+        out = DayItineraryOut(
+            id=1,
+            travel_plan_id=1,
+            date=date_type(2026, 5, 1),
+            notes="",
+            transport="",
+            label="미식 투어",
+            places=[],
+        )
+        assert out.label == "미식 투어"
+
+    def test_set_day_label_day_update_label_none_by_default(self):
+        """DayItineraryOut.label is None when not set."""
+        from app.schemas import DayItineraryOut
+        from datetime import date as date_type
+
+        out = DayItineraryOut(
+            id=1,
+            travel_plan_id=1,
+            date=date_type(2026, 5, 1),
+            notes="",
+            transport="",
+            places=[],
+        )
+        assert out.label is None


### PR DESCRIPTION
## Evolve Run #127
- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: GREEN
- **Task**: #102 - Chat: `set_day_label` intent — set a custom title/label for a day
- **QA**: pass
- **Tests**: 1598/1598 passed (12 skipped)

Closes #140

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #102; health GREEN; architect skipped (backlog_ready_count=3) |
| 📐 Architect | ⏭️ | Skipped — backlog_ready_count ≥ 2 |
| 🔨 Builder | ✅ | 5 files changed (+215/-2): models.py, schemas.py, database.py, chat.py, test_chat.py |
| 🧪 QA | ✅ | All checks pass: 1598 passed, +11 new tests, lint clean, done criteria met, no regressions |
| 📝 Reporter | ✅ | This PR |

### Changes
- `DayItinerary.label` (VARCHAR 200, nullable) added to model with SQLite migration via `ALTER TABLE` in `_apply_migrations()`
- `DayItineraryBase` / `DayItineraryOut` schema gains `Optional[str] label`
- `set_day_label` intent handler: DB path persists label + emits `day_update` SSE with label; in-memory path mutates `session.last_plan` + emits `day_update`
- Error paths: missing day_number, missing label text, out-of-range day, no plan
- 11 new tests in `TestSetDayLabelHandler` class

🤖 Auto-generated by Evolve Pipeline