### PR TITLE
feature(wip): #104 Chat quick_summary intent — needs-review (#104)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -6,17 +6,16 @@
 
 ## In Progress
 
-_(없음)_
-
-## Ready
-
-### Phase 10: Chat + Multi-Agent Dashboard (continued)
-
 - [ ] #104 - Chat: `quick_summary` intent — concise plan overview in chat [feature]
   - ref: markdowns/feat-chat-dashboard.md
   - files: src/app/chat.py, tests/test_chat.py
   - done: "현재 일정 요약해줘" → chat reply with destination, dates, day count, per-day place count, budget % used; no-plan fallback message; 2+ tests
   - gh: #142
+  - ❌ QA fail (Run #129): `integration_test_quality` — all 8 tests mock `extract_intent` (Constraint #10 violation). Fix: add ≥1 test that verifies dispatch table maps 'quick_summary' without intercepting extract_intent (e.g. real stub ChatService call or `skipif`-guarded Gemini smoke).
+
+## Ready
+
+### Phase 10: Chat + Multi-Agent Dashboard (continued)
 
 - [ ] #105 - Frontend: day label badge on day cards [improvement]
   - ref: markdowns/feat-chat-dashboard.md

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,13 +1,13 @@
 {
-  "last_updated": "2026-04-07T18:00:00Z",
+  "last_updated": "2026-04-07T19:00:00Z",
   "summary": {
-    "total_runs": 157,
-    "total_commits": 166,
-    "total_tests": 1598,
+    "total_runs": 158,
+    "total_commits": 167,
+    "total_tests": 1606,
     "tasks_completed": 104,
-    "tasks_remaining": 6,
+    "tasks_remaining": 5,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
-    "health": "GREEN"
+    "health": "YELLOW"
   },
   "daily_trend": [
     {
@@ -66,12 +66,12 @@
     },
     {
       "date": "2026-04-07",
-      "runs": 12,
+      "runs": 13,
       "tasks_completed": 7,
-      "tests_passed": 1598,
+      "tests_passed": 1606,
       "tests_failed": 0,
-      "commits": 33,
-      "health": "GREEN"
+      "commits": 34,
+      "health": "YELLOW"
     }
   ],
   "ltes_7d_avg": {
@@ -87,12 +87,13 @@
     "health": "GREEN"
   },
   "last_evolve": {
-    "timestamp": "2026-04-07T18:00:00Z",
-    "run_id": "2026-04-07-1800",
-    "task": "#103 - E2E: message timestamp Playwright scenarios",
-    "tests_passed": 1598,
+    "timestamp": "2026-04-07T19:00:00Z",
+    "run_id": "2026-04-07-1900",
+    "task": "#104 - Chat: quick_summary intent",
+    "tests_passed": 1606,
     "tests_failed": 0,
-    "health": "GREEN",
-    "qa_verdict": "pass"
+    "health": "YELLOW",
+    "qa_verdict": "fail",
+    "qa_fail_reason": "integration_test_quality: all 8 tests mock extract_intent (Constraint #10)"
   }
 }

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,10 +7,10 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 156,
+    "total_runs": 157,
     "successful_runs": 150,
-    "failed_runs": 1,
-    "success_rate": 0.962,
+    "failed_runs": 2,
+    "success_rate": 0.955,
     "budget_remaining": 0.95,
     "status": "HEALTHY"
   },
@@ -651,8 +651,17 @@
       "tests_total": 1241
     }
   ],
-  "consecutive_qa_failures": 0,
+  "consecutive_qa_failures": 1,
   "history_tail": {
+    "run_id": "2026-04-07-1900",
+    "task": "#104 - Chat: quick_summary intent",
+    "result": "fail",
+    "tests_passed": 1606,
+    "tests_total": 1618,
+    "qa_verdict": "fail",
+    "qa_fail_reason": "integration_test_quality: all 8 tests mock extract_intent (Constraint #10)"
+  },
+  "history_tail_prev": {
     "run_id": "2026-04-07-1800",
     "task": "#103 - E2E: message timestamp Playwright scenarios",
     "result": "success",

--- a/observability/logs/2026-04-07/run-19-00.json
+++ b/observability/logs/2026-04-07/run-19-00.json
@@ -1,0 +1,64 @@
+{
+  "trace": {
+    "run_id": "2026-04-07-1900",
+    "timestamp": "2026-04-07T19:00:00Z",
+    "phase": "Phase 10: Chat + Multi-Agent Dashboard",
+    "health": "YELLOW",
+    "task": "#104 Chat: quick_summary intent — concise plan overview in chat",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "fail",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #104 quick_summary intent. No fix needed, no architect needed."
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "backlog_ready_count=5 >= 3, skipped"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "Implemented _handle_quick_summary handler. 8 new tests in TestQuickSummaryHandler. lines_added=115, lines_removed=0."
+    },
+    {
+      "agent": "qa",
+      "status": "fail",
+      "detail": "all_tests_pass=pass, new_tests_exist=pass, lint_clean=pass, done_criteria_met=pass, no_regressions=pass, integration_test_quality=FAIL (all 8 tests mock extract_intent — Constraint #10 violation), e2e_integration=pass, no_secrets_leaked=pass"
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Writing logs, updating status, posting failure comment on issue #142"
+    }
+  ],
+  "ltes": {
+    "latency": {
+      "total_duration_ms": 50000
+    },
+    "traffic": {
+      "commits": 1,
+      "lines_added": 115,
+      "lines_removed": 0,
+      "files_changed": 2
+    },
+    "errors": {
+      "test_failures": 0,
+      "qa_checks_failed": 1,
+      "fix_attempts": 0,
+      "qa_verdict": "fail",
+      "qa_fail_reason": "integration_test_quality: all 8 new tests mock extract_intent (Constraint #10)"
+    },
+    "saturation": {
+      "backlog_remaining": 5
+    }
+  }
+}

--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -35,7 +35,7 @@ _DEFAULT_DEPARTURE = "서울(ICN)"  # default origin for flight search
 
 
 class Intent(BaseModel):
-    action: str  # create_plan | confirm_plan | modify_day | refine_plan | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | delete_plan | view_plan | add_expense | update_expense | update_plan | get_expense_summary | delete_expense | list_expenses | copy_plan | get_weather | reset_conversation | add_day_note | suggest_improvements | remove_place | add_place | share_plan | reorder_days | clear_day | duplicate_day | move_place | set_day_label | general
+    action: str  # create_plan | confirm_plan | modify_day | refine_plan | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | delete_plan | view_plan | add_expense | update_expense | update_plan | get_expense_summary | delete_expense | list_expenses | copy_plan | get_weather | reset_conversation | add_day_note | suggest_improvements | remove_place | add_place | share_plan | reorder_days | clear_day | duplicate_day | move_place | set_day_label | quick_summary | general
     destination: Optional[str] = None
     start_date: Optional[str] = None
     end_date: Optional[str] = None
@@ -188,7 +188,7 @@ The user is based in South Korea. Budget values should be in KRW (Korean Won). D
 User message: "{message}"
 
 Return a JSON object with these fields:
-- action: one of "create_plan", "confirm_plan", "modify_day", "refine_plan", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "add_expense", "update_expense", "update_plan", "get_expense_summary", "delete_expense", "list_expenses", "copy_plan", "get_weather", "reset_conversation", "add_day_note", "suggest_improvements", "remove_place", "add_place", "share_plan", "reorder_days", "clear_day", "duplicate_day", "move_place", "set_day_label", "general"
+- action: one of "create_plan", "confirm_plan", "modify_day", "refine_plan", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "add_expense", "update_expense", "update_plan", "get_expense_summary", "delete_expense", "list_expenses", "copy_plan", "get_weather", "reset_conversation", "add_day_note", "suggest_improvements", "remove_place", "add_place", "share_plan", "reorder_days", "clear_day", "duplicate_day", "move_place", "set_day_label", "quick_summary", "general"
 - Use action "confirm_plan" when the user confirms they want to proceed with creating a travel plan (e.g. "네 세워줘", "좋아 계획해줘", "응 진행해", "yes please", "go ahead", "확인")
 - IMPORTANT: Use action "general" for casual conversation, questions, opinions, or when the user is discussing/exploring options but NOT explicitly requesting to create or modify a plan. Examples: "후쿠오카 4박 5일은 너무 길지 않을까?" → general (asking opinion), "여행지 추천해줘" → general (asking for suggestions), "벌레 싫은데" → general (sharing preference)
 - Use "create_plan" ONLY when the user explicitly asks to CREATE a plan with specific details. Use "refine_plan" ONLY when the user explicitly asks to CHANGE an existing plan (e.g. "일정 수정해줘", "3일차 바꿔줘")
@@ -222,6 +222,7 @@ Return a JSON object with these fields:
 - Use action "duplicate_day" when user wants to copy all places from one day to another day (e.g. "2일차 일정을 4일차에도 넣어줘", "1일차 복사해서 3일차에 붙여줘", "Day 2 일정을 Day 4로 복사", "copy day 1 to day 3", "2일차랑 똑같이 4일차도 만들어줘"); set day_number to the SOURCE day and day_number_2 to the TARGET day
 - Use action "move_place" when user wants to move/transfer a specific place from one day to another day (e.g. "1일차 두 번째 장소를 3일차로 옮겨줘", "Day 2에서 센소지를 Day 4로 이동해줘", "3일차 첫 번째 장소를 1일차로 옮겨", "move place from day 1 to day 3", "2일차 루브르를 3일차로 이동"); set day_number to the SOURCE day, day_number_2 to the TARGET day, query to the place name if mentioned, and place_index to the 1-based position if an ordinal is mentioned (e.g. "첫 번째" → 1, "두 번째" → 2, "마지막" → -1)
 - Use action "set_day_label" when user wants to give a custom title/label/name to a specific day (e.g. "1일차 이름을 '미식 투어'로 해줘", "Day 2 제목을 '자연 탐방'으로 설정해줘", "3일차 이름 바꿔줘, '쇼핑 데이'로", "set day 1 label to 'Food Tour'", "name day 3 'Beach Day'", "Day 2 타이틀을 '박물관 투어'로 해줘"); set day_number to the referenced day and query to the label text
+- Use action "quick_summary" when user wants a concise overview or summary of the current travel plan (e.g. "현재 일정 요약해줘", "여행 계획 요약", "계획 간단히 알려줘", "일정 요약해줘", "plan summary", "summarize my trip", "여행 일정 요약", "지금 계획 어떻게 돼?")
 - raw_message: the exact original message"""
 
             client = genai.Client(api_key=self._api_key)
@@ -424,6 +425,9 @@ Return a JSON object with these fields:
                 yield _track_and_collect(event)
         elif intent.action == "set_day_label":
             async for event in self._handle_set_day_label(intent, session, db):
+                yield _track_and_collect(event)
+        elif intent.action == "quick_summary":
+            async for event in self._handle_quick_summary(intent, session):
                 yield _track_and_collect(event)
         else:  # general
             async for event in self._handle_general(intent, session):
@@ -4324,6 +4328,77 @@ Return a JSON object with these fields:
                 "type": "chat_chunk",
                 "data": {"text": "레이블을 설정하려면 먼저 여행 계획을 만들거나 저장해주세요."},
             }
+
+
+    async def _handle_quick_summary(
+        self,
+        intent: Intent,
+        session: "ChatSession",
+    ) -> AsyncGenerator[dict, None]:
+        """Return a concise overview of the current travel plan.
+
+        Emits a chat_chunk with destination, dates, day count, per-day place
+        count, and budget % used.  Falls back gracefully when no plan exists.
+        """
+        yield {
+            "type": "agent_status",
+            "data": {"agent": "coordinator", "status": "working", "message": "일정 요약 준비 중..."},
+        }
+        await asyncio.sleep(0)
+
+        last_plan = session.last_plan
+        if not last_plan:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "coordinator", "status": "done", "message": "요약할 계획이 없습니다"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": "아직 여행 계획이 없습니다. '도쿄 3박4일 계획 세워줘'처럼 먼저 계획을 만들어보세요!"},
+            }
+            return
+
+        destination = last_plan.get("destination") or "목적지 미지정"
+        start_date = last_plan.get("start_date") or ""
+        end_date = last_plan.get("end_date") or ""
+        budget = last_plan.get("budget") or 0
+        total_estimated_cost = last_plan.get("total_estimated_cost") or 0
+        days = last_plan.get("days") or []
+        day_count = len(days)
+
+        per_day_lines = []
+        for day in days:
+            dn = day.get("day_number", "?")
+            places = day.get("places") or []
+            per_day_lines.append(f"  Day {dn}: {len(places)}개 장소")
+
+        budget_pct = (total_estimated_cost / budget * 100) if budget > 0 else 0
+
+        lines = [f"📍 {destination} 여행 계획 요약"]
+        if start_date and end_date:
+            lines.append(f"📅 기간: {start_date} ~ {end_date} ({day_count}일)")
+        else:
+            lines.append(f"📅 총 {day_count}일 일정")
+
+        if per_day_lines:
+            lines.append("🗓️ 일정:")
+            lines.extend(per_day_lines)
+
+        if budget > 0:
+            lines.append(
+                f"💰 예산: {budget:,.0f}원 중 {total_estimated_cost:,.0f}원 사용 ({budget_pct:.0f}%)"
+            )
+
+        summary_text = "\n".join(lines)
+
+        yield {
+            "type": "agent_status",
+            "data": {"agent": "coordinator", "status": "done", "message": "일정 요약 완료"},
+        }
+        yield {
+            "type": "chat_chunk",
+            "data": {"text": summary_text},
+        }
 
 
 # Module-level singleton used by the chat router

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-07T18:00:00Z (Evolve Run #128)
-Run count: 156
+Last run: 2026-04-07T19:00:00Z (Evolve Run #129)
+Run count: 157
 Phase: Phase 10: Chat + Multi-Agent Dashboard
-Health: GREEN
+Health: YELLOW
 Error Budget: HEALTHY
 Tasks completed: 104 (#103 E2E: message timestamp — 3 Playwright scenarios: new bubbles show 방금, multi-exchange timestamps, reconnect restores 분 전)
-Current focus: #104 Chat: quick_summary intent
-Next planned: #105 Frontend: day label badge on day cards
+Current focus: #104 Chat: quick_summary intent (QA failed — needs integration test fix)
+Next planned: #104 retry (integration_test_quality: extract_intent mock violation)
 
 ## LTES Snapshot
 
 - Latency: ~50000ms (evolve run)
 - Traffic: 1 commit/run
-- Errors: 0 test failures (1598 passed, 12 skipped), error_rate=0.0%
-- Saturation: 6 tasks ready
+- Errors: 0 test failures (1606 passed, 12 skipped) but QA fail (integration_test_quality), error_rate=0.0%
+- Saturation: 5 tasks ready
 
 ## Phase Transition
 
@@ -29,6 +29,16 @@ Next planned: #105 Frontend: day label badge on day cards
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #129 — 2026-04-07T19:00:00Z
+- **Task**: #104 - Chat: `quick_summary` intent — concise plan overview in chat [feature]
+- **Result**: YELLOW ✗ (QA fail)
+- **Tests**: 1606/1618 passed, 12 skipped (pre-existing LLM smoke skips); 8 new tests added (TestQuickSummaryHandler) — all pass
+- **Files changed**: src/app/chat.py (+115/-0), tests/test_chat.py (+115/-0)
+- **QA fail reason**: `integration_test_quality` — all 8 new tests use `patch.object(svc, 'extract_intent')` to bypass intent extraction, violating Constraint #10. The full request→intent→handler path is not exercised end-to-end. Remediation: add at least one test that does NOT mock `extract_intent` (real dispatch table verification or `skipif`-guarded Gemini call).
+- **QA pass checks**: all_tests_pass ✓, new_tests_exist ✓, lint_clean ✓, done_criteria_met ✓, no_regressions ✓, e2e_integration ✓ (5/5 Playwright), no_secrets_leaked ✓
+- **LTES**: L=50000ms T=1 commit E=1 qa_check_fail S=5 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✗ → reporter ✓
 
 ### Evolve Run #128 — 2026-04-07T18:00:00Z
 - **Task**: #103 - E2E: message timestamp Playwright scenarios [test]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -8454,3 +8454,184 @@ class TestSetDayLabelHandler:
             places=[],
         )
         assert out.label is None
+
+
+# ---------------------------------------------------------------------------
+# Task #104: quick_summary intent — concise plan overview in chat
+# ---------------------------------------------------------------------------
+
+class TestQuickSummaryHandler:
+    """_handle_quick_summary: emit chat_chunk with plan overview; fallback when no plan."""
+
+    def test_quick_summary_intent_accepted_by_model(self):
+        """Intent model must accept quick_summary as a valid action."""
+        intent = Intent(action="quick_summary", raw_message="현재 일정 요약해줘")
+        assert intent.action == "quick_summary"
+
+    def test_quick_summary_no_plan_emits_fallback_message(self):
+        """quick_summary with no plan emits a helpful fallback chat_chunk."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        # session.last_plan is None by default
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="quick_summary", raw_message="현재 일정 요약해줘"
+        )):
+            events = _collect_events(svc, session.session_id, "현재 일정 요약해줘")
+
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        # At least one must mention that no plan exists
+        text = " ".join(e["data"]["text"] for e in chat_chunks)
+        assert "계획" in text or "plan" in text.lower()
+
+    def test_quick_summary_with_plan_includes_destination(self):
+        """quick_summary with a plan includes destination in the reply."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "도쿄",
+            "start_date": "2026-05-01",
+            "end_date": "2026-05-04",
+            "budget": 2000000,
+            "total_estimated_cost": 1360000,
+            "days": [
+                {"day_number": 1, "date": "2026-05-01", "places": [{"name": "센소지"}, {"name": "스카이트리"}]},
+                {"day_number": 2, "date": "2026-05-02", "places": [{"name": "시부야"}]},
+                {"day_number": 3, "date": "2026-05-03", "places": []},
+            ],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="quick_summary", raw_message="현재 일정 요약해줘"
+        )):
+            events = _collect_events(svc, session.session_id, "현재 일정 요약해줘")
+
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        text = " ".join(e["data"]["text"] for e in chat_chunks)
+        assert "도쿄" in text
+
+    def test_quick_summary_with_plan_includes_dates_and_day_count(self):
+        """quick_summary reply includes start_date, end_date, and day count."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "파리",
+            "start_date": "2026-06-01",
+            "end_date": "2026-06-05",
+            "budget": 3000000,
+            "total_estimated_cost": 1500000,
+            "days": [
+                {"day_number": 1, "date": "2026-06-01", "places": [{"name": "에펠탑"}]},
+                {"day_number": 2, "date": "2026-06-02", "places": []},
+                {"day_number": 3, "date": "2026-06-03", "places": []},
+                {"day_number": 4, "date": "2026-06-04", "places": []},
+                {"day_number": 5, "date": "2026-06-05", "places": []},
+            ],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="quick_summary", raw_message="일정 요약해줘"
+        )):
+            events = _collect_events(svc, session.session_id, "일정 요약해줘")
+
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        text = " ".join(e["data"]["text"] for e in chat_chunks)
+        assert "2026-06-01" in text
+        assert "2026-06-05" in text
+        assert "5" in text  # 5 days
+
+    def test_quick_summary_with_plan_includes_per_day_place_count(self):
+        """quick_summary reply includes per-day place count."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "오사카",
+            "start_date": "2026-07-01",
+            "end_date": "2026-07-03",
+            "budget": 1500000,
+            "total_estimated_cost": 900000,
+            "days": [
+                {"day_number": 1, "date": "2026-07-01", "places": [{"name": "도톤보리"}, {"name": "신사이바시"}]},
+                {"day_number": 2, "date": "2026-07-02", "places": [{"name": "오사카성"}]},
+                {"day_number": 3, "date": "2026-07-03", "places": []},
+            ],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="quick_summary", raw_message="여행 계획 요약해줘"
+        )):
+            events = _collect_events(svc, session.session_id, "여행 계획 요약해줘")
+
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        text = " ".join(e["data"]["text"] for e in chat_chunks)
+        # Day 1 has 2 places, Day 2 has 1 place
+        assert "2" in text
+        assert "1" in text
+
+    def test_quick_summary_with_plan_includes_budget_percentage(self):
+        """quick_summary reply includes budget % used when budget > 0."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "방콕",
+            "start_date": "2026-08-01",
+            "end_date": "2026-08-04",
+            "budget": 2000000,
+            "total_estimated_cost": 1000000,
+            "days": [
+                {"day_number": 1, "date": "2026-08-01", "places": []},
+            ],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="quick_summary", raw_message="현재 계획 요약"
+        )):
+            events = _collect_events(svc, session.session_id, "현재 계획 요약")
+
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        text = " ".join(e["data"]["text"] for e in chat_chunks)
+        # 1,000,000 / 2,000,000 = 50%
+        assert "50" in text
+
+    def test_quick_summary_emits_coordinator_done_status(self):
+        """quick_summary emits coordinator agent_status done."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "뉴욕",
+            "start_date": "2026-09-01",
+            "end_date": "2026-09-03",
+            "budget": 5000000,
+            "total_estimated_cost": 2000000,
+            "days": [{"day_number": 1, "date": "2026-09-01", "places": []}],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="quick_summary", raw_message="계획 요약해줘"
+        )):
+            events = _collect_events(svc, session.session_id, "계획 요약해줘")
+
+        agent_events = [e for e in events if e["type"] == "agent_status" and e["data"]["agent"] == "coordinator"]
+        assert any(e["data"]["status"] == "done" for e in agent_events)
+
+    def test_quick_summary_no_budget_omits_budget_line(self):
+        """quick_summary reply omits budget line when budget is 0/None."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "런던",
+            "start_date": "2026-10-01",
+            "end_date": "2026-10-02",
+            "budget": 0,
+            "total_estimated_cost": 0,
+            "days": [{"day_number": 1, "date": "2026-10-01", "places": []}],
+        }
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="quick_summary", raw_message="계획 요약"
+        )):
+            events = _collect_events(svc, session.session_id, "계획 요약")
+
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        text = " ".join(e["data"]["text"] for e in chat_chunks)
+        assert "%" not in text


### PR DESCRIPTION
## Evolve Run #129
- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: YELLOW
- **Task**: #104 Chat: `quick_summary` intent — concise plan overview in chat
- **QA**: ❌ fail

### QA Results

| Check | Result | Detail |
|-------|--------|--------|
| all_tests_pass | ✅ | 1606 passed, 12 skipped |
| new_tests_exist | ✅ | 8 new tests in TestQuickSummaryHandler |
| lint_clean | ✅ | ruff: all checks passed |
| done_criteria_met | ✅ | destination, dates, day count, per-day places, budget %, fallback |
| no_regressions | ✅ | 1618 collected (up from 1610), no previously-passing test failing |
| integration_test_quality | ❌ | All 8 tests mock `extract_intent` — Constraint #10 violation |
| e2e_integration | ✅ | Playwright 5/5 passed |
| no_secrets_leaked | ✅ | No hardcoded API keys |

### ❌ QA Failure Detail

All `TestQuickSummaryHandler` tests use `patch.object(svc, 'extract_intent')` to bypass intent extraction. This violates **Constraint #10** which forbids mocking core logic. The full request→intent→handler path is not verified end-to-end.

**Remediation**: Add ≥1 test that does NOT mock `extract_intent` — either verify the dispatch table maps `'quick_summary'` action without intercepting extract_intent, or add a `@pytest.mark.skipif`-guarded test with a real/stubbed Gemini response.

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #104, no fix/architect needed |
| 📐 Architect | ⏭️ | Skipped (backlog_ready_count=5 ≥ 3) |
| 🔨 Builder | ✅ | src/app/chat.py, tests/test_chat.py (+115 lines) |
| 🧪 QA | ❌ | integration_test_quality fail |
| 📝 Reporter | ✅ | This PR |

🤖 Auto-generated by Evolve Pipeline