### PR TITLE
improvement: #105 Frontend — day label badge on day cards (#105)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -12,13 +12,6 @@ _(없음)_
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
 
-- [ ] #105 - Frontend: day label badge on day cards [improvement]
-  - ref: markdowns/feat-chat-dashboard.md
-  - depends: #102
-  - files: src/app/static/chat.js, src/app/static/index.html
-  - done: day card shows label as styled subtitle/badge when day.label present; handleDayUpdate refreshes label; 2+ tests
-  - gh: #168
-
 - [ ] #106 - E2E: `quick_summary` Playwright scenarios [test]
   - ref: markdowns/feat-chat-dashboard.md
   - depends: #104
@@ -168,6 +161,7 @@ _(없음)_
 - [x] #102 - Chat: `set_day_label` intent — set a custom title/label for a day [feature] — 2026-04-07
 - [x] #103 - E2E: message timestamp Playwright scenarios [test] — 2026-04-07
 - [x] #104 - Chat: `quick_summary` intent — concise plan overview in chat [feature] — 2026-04-07
+- [x] #105 - Frontend: day label badge on day cards [improvement] — 2026-04-07
 
 ### Phase 9: User Experience & Polish (remaining, completed)
 - [x] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature] — 2026-04-04
@@ -180,5 +174,5 @@ _(없음)_
 ## Metrics
 
 - Velocity: 1 task/run
-- Total tasks: 105 done, 5 ready (0 in progress)
+- Total tasks: 106 done, 4 ready (0 in progress)
 - Phase: 10 (Chat + Multi-Agent Dashboard)

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,11 +1,11 @@
 {
-  "last_updated": "2026-04-07T20:05:09Z",
+  "last_updated": "2026-04-07T21:00:00Z",
   "summary": {
-    "total_runs": 159,
-    "total_commits": 167,
-    "total_tests": 1608,
-    "tasks_completed": 105,
-    "tasks_remaining": 5,
+    "total_runs": 160,
+    "total_commits": 168,
+    "total_tests": 1611,
+    "tasks_completed": 106,
+    "tasks_remaining": 4,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
     "health": "GREEN"
   },
@@ -66,11 +66,11 @@
     },
     {
       "date": "2026-04-07",
-      "runs": 14,
-      "tasks_completed": 8,
-      "tests_passed": 1608,
+      "runs": 15,
+      "tasks_completed": 9,
+      "tests_passed": 1611,
       "tests_failed": 0,
-      "commits": 34,
+      "commits": 35,
       "health": "GREEN"
     }
   ],
@@ -87,10 +87,10 @@
     "health": "GREEN"
   },
   "last_evolve": {
-    "timestamp": "2026-04-07T19:00:00Z",
-    "run_id": "2026-04-07-1900",
-    "task": "#104 - Chat: quick_summary intent — concise plan overview in chat",
-    "tests_passed": 1608,
+    "timestamp": "2026-04-07T21:00:00Z",
+    "run_id": "2026-04-07-2100",
+    "task": "#105 - Frontend: day label badge on day cards",
+    "tests_passed": 1611,
     "tests_failed": 0,
     "health": "GREEN",
     "qa_verdict": "pass"

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,8 +7,8 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 158,
-    "successful_runs": 152,
+    "total_runs": 159,
+    "successful_runs": 153,
     "failed_runs": 1,
     "success_rate": 0.962,
     "budget_remaining": 0.95,
@@ -653,11 +653,11 @@
   ],
   "consecutive_qa_failures": 0,
   "history_tail": {
-    "run_id": "2026-04-07-1900",
-    "task": "#104 - Chat: quick_summary intent — concise plan overview in chat",
+    "run_id": "2026-04-07-2100",
+    "task": "#105 - Frontend: day label badge on day cards",
     "result": "success",
-    "tests_passed": 1608,
-    "tests_total": 1620
+    "tests_passed": 1611,
+    "tests_total": 1623
   },
   "history_tail_prev2_prev": {
     "run_id": "2026-04-07-1600",

--- a/observability/logs/2026-04-07/run-21-00.json
+++ b/observability/logs/2026-04-07/run-21-00.json
@@ -1,0 +1,49 @@
+{
+  "trace": {
+    "run_id": "2026-04-07-2100",
+    "timestamp": "2026-04-07T21:00:00Z",
+    "phase": "Phase 10: Chat + Multi-Agent Dashboard",
+    "health": "GREEN",
+    "task": "#105 - Frontend: day label badge on day cards",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "skipped",
+      "builder": "completed",
+      "qa": "pass",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #105 — day label badge on day cards; no fix needed, no architect needed (4 ready tasks)"
+    },
+    {
+      "agent": "architect",
+      "status": "skipped",
+      "detail": "Backlog has 4 ready tasks — architect not required"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "Added .day-label-badge span in _dayCardHtml; handleDayUpdate creates/updates/removes badge; CSS class in index.html; 3 tests added in TestDayLabelBadge; 28 lines added, 0 removed"
+    },
+    {
+      "agent": "qa",
+      "status": "pass",
+      "detail": "all_tests_pass:pass, new_tests_exist:pass, lint_clean:pass, done_criteria_met:pass, no_regressions:pass(+3 net), integration_test_quality:pass, e2e_integration:pass, no_secrets_leaked:pass"
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Writing logs, updating status/backlog/budget, creating PR"
+    }
+  ],
+  "ltes": {
+    "latency": {"total_duration_ms": 50000},
+    "traffic": {"commits": 1, "lines_added": 28, "lines_removed": 0, "files_changed": 3},
+    "errors": {"test_failures": 0, "fix_attempts": 0},
+    "saturation": {"backlog_remaining": 4}
+  }
+}

--- a/src/app/static/chat.js
+++ b/src/app/static/chat.js
@@ -966,6 +966,7 @@ function _dayCardHtml(day) {
       <strong>${escHtml(day.date)}</strong>
       ${dayCost > 0 ? `<span class="price-tag">${dayCost.toLocaleString()}원</span>` : ''}
     </div>
+    ${day.label ? `<span class="day-label-badge">${escHtml(day.label)}</span>` : ''}
     ${day.notes ? `<div class="meta">${escHtml(day.notes)}</div>` : ''}
     <div class="day-places">${places || '<div class="meta">장소 없음</div>'}</div>
   </div>`;
@@ -996,6 +997,21 @@ function handleDayUpdate(data) {
   const placesEl = dayEl.querySelector('.day-places');
   if (placesEl && data.places) {
     placesEl.innerHTML = data.places.map(p => _placeItemHtml(p)).join('');
+  }
+  // Update day label badge
+  let labelEl = dayEl.querySelector('.day-label-badge');
+  if (data.label) {
+    if (labelEl) {
+      labelEl.textContent = data.label;
+    } else {
+      labelEl = document.createElement('span');
+      labelEl.className = 'day-label-badge';
+      labelEl.textContent = data.label;
+      const header = dayEl.querySelector('div');
+      if (header) header.insertAdjacentElement('afterend', labelEl);
+    }
+  } else if (labelEl) {
+    labelEl.remove();
   }
   // Update day cost
   const dayCost = (data.places || []).reduce((s, p) => s + (p.estimated_cost || 0), 0);

--- a/src/app/static/index.html
+++ b/src/app/static/index.html
@@ -134,6 +134,7 @@
   .plan-budget { margin-bottom: .75rem; }
   .budget-row { display: flex; justify-content: space-between; }
   .day-card { margin-bottom: .75rem; }
+  .day-label-badge { display: inline-block; background: #e8f0fe; color: #1a73e8; padding: .15rem .55rem; border-radius: 10px; font-size: .78rem; font-weight: 500; margin: .25rem 0 .1rem; }
   .plan-search-section { margin-top: 1rem; }
   /* ── Compact agent panel (always compact, shows active agents inline) ──── */
   #agent-panel-compact-row { display: flex; align-items: center; gap: .5rem; padding: .35rem .5rem;

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-07T20:05:09Z (Monitor Run #138)
-Run count: 158
+Last run: 2026-04-07T21:00:00Z (Evolve Run #130)
+Run count: 159
 Phase: Phase 10: Chat + Multi-Agent Dashboard
 Health: GREEN
 Error Budget: HEALTHY
-Tasks completed: 105 (#104 Chat: quick_summary intent — destination, dates, day count, per-day place count, budget % used; no-plan fallback; 10 new tests)
-Current focus: #105 Frontend: day label badge on day cards
-Next planned: #106 E2E: quick_summary Playwright scenarios
+Tasks completed: 106 (#105 Frontend: day label badge on day cards — .day-label-badge badge renders when day.label present; handleDayUpdate refreshes/removes badge; CSS; 3 new tests)
+Current focus: #106 E2E: quick_summary Playwright scenarios
+Next planned: #107 Chat: swap_places intent
 
 ## LTES Snapshot
 
-- Latency: ~64902ms (monitor run, pytest 42.28s)
-- Traffic: 30 commits/24h
-- Errors: 0 test failures (1608 passed, 12 skipped), error_rate=0.0%
-- Saturation: 5 tasks ready (#105, #106, #107, #108, #109)
+- Latency: ~50000ms (evolve run)
+- Traffic: 1 commit
+- Errors: 0 test failures (1611 passed, 12 skipped), error_rate=0.0%
+- Saturation: 4 tasks ready (#106, #107, #108, #109)
 
 ## Phase Transition
 
@@ -29,6 +29,15 @@ Next planned: #106 E2E: quick_summary Playwright scenarios
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #130 — 2026-04-07T21:00:00Z
+- **Task**: #105 - Frontend: day label badge on day cards [improvement]
+- **Result**: GREEN ✓ (QA pass)
+- **Tests**: 1611/1611 passed, 12 skipped; 3 new tests added (TestDayLabelBadge: test_chat_js_day_card_html_renders_label_badge, test_chat_js_handle_day_update_refreshes_label, test_index_html_has_day_label_badge_css)
+- **Files changed**: src/app/static/chat.js, src/app/static/index.html, tests/test_frontend.py (+28/-0)
+- **Builder note**: Added .day-label-badge span in _dayCardHtml at chat.js:969 when day.label present. handleDayUpdate (chat.js:1001-1014) creates/updates/removes badge when data.label changes. CSS class .day-label-badge added to index.html:137. No new E2E spec needed (frontend styling/JS improvement, no new SSE events or API endpoints).
+- **LTES**: L=50000ms T=1 commit E=0 test failures S=4 tasks remaining
+- **Agents**: coordinator ✓ → architect ⏭️ → builder ✓ → qa ✓ → reporter ✓
 
 ### Evolve Run #129 — 2026-04-07T19:00:00Z
 - **Task**: #104 - Chat: `quick_summary` intent — concise plan overview in chat [feature]

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -407,3 +407,31 @@ class TestModernUXRedesign:
             end_idx = idx + 3000
         fn_body = content[idx:end_idx]
         assert "navigate('chat')" in fn_body
+
+
+class TestDayLabelBadge:
+    """Task #105: day card shows label as styled subtitle/badge when day.label present."""
+
+    def test_chat_js_day_card_html_renders_label_badge(self, client: TestClient):
+        """_dayCardHtml renders a day-label-badge span when day.label is truthy."""
+        content = client.get("/static/chat.js").text
+        # _dayCardHtml must reference the day-label-badge class and day.label
+        assert "day-label-badge" in content
+        assert "day.label" in content
+
+    def test_chat_js_handle_day_update_refreshes_label(self, client: TestClient):
+        """handleDayUpdate creates/updates .day-label-badge on existing day cards."""
+        content = client.get("/static/chat.js").text
+        # Find handleDayUpdate function body
+        idx = content.find("function handleDayUpdate")
+        assert idx != -1
+        end_idx = content.find("\nfunction ", idx + 1)
+        body = content[idx:end_idx] if end_idx != -1 else content[idx:]
+        # Must reference label badge inside the update handler
+        assert "day-label-badge" in body
+        assert "data.label" in body
+
+    def test_index_html_has_day_label_badge_css(self, client: TestClient):
+        """index.html defines .day-label-badge CSS class."""
+        content = client.get("/").text
+        assert "day-label-badge" in content


### PR DESCRIPTION
## Evolve Run #130
- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: GREEN
- **Task**: #105 - Frontend: day label badge on day cards
- **QA**: pass
- **Tests**: 1611/1623 passed (12 skipped — pre-existing Gemini API rate-limit skips)

Closes #168

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #105; no fix needed, architect skipped (4 ready tasks) |
| 📐 Architect | ⏭️ | Skipped — sufficient ready tasks in backlog |
| 🔨 Builder | ✅ | Added .day-label-badge span in _dayCardHtml; handleDayUpdate creates/updates/removes badge; CSS class in index.html; 3 tests added (+28 lines) |
| 🧪 QA | ✅ | All 8 checks passed: tests, new_tests, lint, done_criteria, no_regressions(+3 net), integration_quality, e2e_integration, no_secrets |
| 📝 Reporter | ✅ | This PR |

🤖 Auto-generated by Evolve Pipeline