### PR TITLE
feat: #108 Chat: find_alternatives intent — suggest replacement places for a slot (#171)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -12,18 +12,43 @@ _(없음)_
 
 ### Phase 10: Chat + Multi-Agent Dashboard (continued)
 
-- [ ] #108 - Chat: `find_alternatives` intent — suggest replacement places for a slot [feature]
-  - ref: markdowns/feat-chat-dashboard.md
-  - files: src/app/chat.py, tests/test_chat.py
-  - done: search_results SSE with alternatives; agent_status for place_scout; 2+ tests (happy path, no-plan fallback)
-  - gh: #171
-
 - [ ] #109 - E2E: `set_day_label` + day label display Playwright scenarios [test]
   - ref: markdowns/feat-chat-dashboard.md
   - depends: #105
   - files: e2e/chat.spec.ts
   - done: 2+ Playwright assertions: label visible after day_update SSE; absent when label is null; no existing tests broken
   - gh: #172
+
+- [ ] #110 - E2E: `find_alternatives` Playwright scenarios [test]
+  - ref: markdowns/feat-chat-dashboard.md
+  - depends: #108
+  - files: e2e/chat.spec.ts
+  - done: 2+ Playwright scenarios — alternatives render in search_results panel; fallback when no plan exists; no existing tests broken
+  - gh: #178
+
+- [ ] #111 - Chat: `add_day` intent — extend trip by appending a new day [feature]
+  - ref: markdowns/feat-chat-dashboard.md
+  - files: src/app/chat.py, tests/test_chat.py
+  - done: `add_day` in dispatcher + extraction prompt; `_handle_add_day()` extends plan end_date, generates new day via GeminiService, persists to DB, emits `day_update` + planner agent_status; 2+ tests (happy path, no-plan fallback)
+  - gh: #179
+
+- [ ] #112 - Chat: `remove_day` intent — remove a day from the trip [feature]
+  - ref: markdowns/feat-chat-dashboard.md
+  - files: src/app/chat.py, tests/test_chat.py
+  - done: `remove_day` in dispatcher + extraction prompt; `_handle_remove_day()` deletes itinerary row, updates plan end_date, renumbers remaining days, emits `day_update` for shifted days + `plan_update`; 2+ tests (happy path, no-plan fallback, out-of-range)
+  - gh: #180
+
+- [ ] #113 - E2E: `place_preview` card display during `create_plan` [test]
+  - ref: markdowns/feat-chat-dashboard.md
+  - files: e2e/chat.spec.ts
+  - done: 2+ Playwright scenarios — `.place-card` elements appear in plan panel after `place_preview` SSE events; each card shows name + category; cards accumulate as events arrive
+  - gh: #181
+
+- [ ] #114 - Chat: `update_day_note` intent — overwrite or clear a day's note [feature]
+  - ref: markdowns/feat-chat-dashboard.md
+  - files: src/app/chat.py, tests/test_chat.py
+  - done: `update_day_note` in dispatcher + extraction prompt (distinct from `add_day_note` append); `_handle_update_day_note()` replaces or clears note in DB, emits `day_update`; 2+ tests (replace, clear, no-plan fallback)
+  - gh: #182
 
 ## Blocked
 
@@ -151,6 +176,7 @@ _(없음)_
 - [x] #105 - Frontend: day label badge on day cards [improvement] — 2026-04-07
 - [x] #106 - E2E: `quick_summary` Playwright scenarios [test] — 2026-04-07
 - [x] #107 - Chat: `swap_places` intent — swap places between two days [feature] — 2026-04-07
+- [x] #108 - Chat: `find_alternatives` intent — suggest replacement places for a slot [feature] — 2026-04-07
 
 ### Phase 9: User Experience & Polish (remaining, completed)
 - [x] #35 - Per-day cost summary (`GET /plans/{id}/itineraries/{day_id}/stats` → place count, total estimated cost, category breakdown dict) [feature] — 2026-04-04
@@ -163,5 +189,5 @@ _(없음)_
 ## Metrics
 
 - Velocity: 1 task/run
-- Total tasks: 108 done, 2 ready (0 in progress)
+- Total tasks: 109 done, 6 ready (0 in progress)
 - Phase: 10 (Chat + Multi-Agent Dashboard)

--- a/observability/dashboard.json
+++ b/observability/dashboard.json
@@ -1,11 +1,11 @@
 {
-  "last_updated": "2026-04-07T23:00:00Z",
+  "last_updated": "2026-04-07T21:27:29Z",
   "summary": {
-    "total_runs": 163,
-    "total_commits": 170,
-    "total_tests": 1623,
-    "tasks_completed": 108,
-    "tasks_remaining": 2,
+    "total_runs": 164,
+    "total_commits": 171,
+    "total_tests": 1630,
+    "tasks_completed": 109,
+    "tasks_remaining": 6,
     "current_phase": "Phase 10: Chat + Multi-Agent Dashboard",
     "health": "GREEN"
   },
@@ -66,11 +66,11 @@
     },
     {
       "date": "2026-04-07",
-      "runs": 19,
-      "tasks_completed": 11,
-      "tests_passed": 1623,
+      "runs": 20,
+      "tasks_completed": 12,
+      "tests_passed": 1630,
       "tests_failed": 0,
-      "commits": 30,
+      "commits": 31,
       "health": "GREEN"
     }
   ],
@@ -87,10 +87,10 @@
     "health": "GREEN"
   },
   "last_evolve": {
-    "timestamp": "2026-04-07T23:00:00Z",
-    "run_id": "2026-04-07-2300",
-    "task": "#107 - Chat: swap_places intent — swap places between two days",
-    "tests_passed": 1623,
+    "timestamp": "2026-04-07T21:27:29Z",
+    "run_id": "2026-04-07-2400",
+    "task": "#108 - Chat: find_alternatives intent — suggest replacement places for a slot",
+    "tests_passed": 1630,
     "tests_failed": 0,
     "health": "GREEN",
     "qa_verdict": "pass"

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -7,8 +7,8 @@
   "current_period": {
     "start": "2026-04-01",
     "end": "2026-04-07",
-    "total_runs": 163,
-    "successful_runs": 157,
+    "total_runs": 164,
+    "successful_runs": 158,
     "failed_runs": 1,
     "success_rate": 0.963,
     "budget_remaining": 0.95,
@@ -653,11 +653,11 @@
   ],
   "consecutive_qa_failures": 0,
   "history_tail": {
-    "run_id": "2026-04-07-2300",
-    "task": "#107 - Chat: swap_places intent — swap places between two days",
+    "run_id": "2026-04-07-2400",
+    "task": "#108 - Chat: find_alternatives intent — suggest replacement places for a slot",
     "result": "success",
-    "tests_passed": 1623,
-    "tests_total": 1623
+    "tests_passed": 1630,
+    "tests_total": 1630
   },
   "history_tail_prev2_prev": {
     "run_id": "2026-04-07-1600",

--- a/observability/logs/2026-04-07/run-21-27.json
+++ b/observability/logs/2026-04-07/run-21-27.json
@@ -1,0 +1,61 @@
+{
+  "trace": {
+    "run_id": "2026-04-07-2400",
+    "timestamp": "2026-04-07T21:27:29Z",
+    "phase": "Phase 10: Chat + Multi-Agent Dashboard",
+    "health": "GREEN",
+    "task": "#108 - Chat: find_alternatives intent — suggest replacement places for a slot",
+    "agents": {
+      "coordinator": "completed",
+      "architect": "completed",
+      "builder": "completed",
+      "qa": "pass",
+      "reporter": "running"
+    }
+  },
+  "spans": [
+    {
+      "agent": "coordinator",
+      "status": "completed",
+      "detail": "Selected task #108; needs_architect=true; health=GREEN; 2 tasks ready"
+    },
+    {
+      "agent": "architect",
+      "status": "completed",
+      "detail": "Spec reviewed from markdowns/feat-chat-dashboard.md; task scoped to src/app/chat.py + tests/test_chat.py"
+    },
+    {
+      "agent": "builder",
+      "status": "completed",
+      "detail": "find_alternatives handler implemented; place_scout agent_status working→done; search_results SSE with type=alternatives; 7 new tests; 1631 total tests pass; ruff clean"
+    },
+    {
+      "agent": "qa",
+      "status": "pass",
+      "detail": "1630 passed, 12 skipped; all checks pass: tests, new_tests, lint, done_criteria, no_regressions, integration_test_quality, e2e_integration, no_secrets_leaked"
+    },
+    {
+      "agent": "reporter",
+      "status": "running",
+      "detail": "Writing logs, updating status/backlog/budget, creating PR"
+    }
+  ],
+  "ltes": {
+    "latency": {
+      "total_duration_ms": 50000
+    },
+    "traffic": {
+      "commits": 1,
+      "lines_added": 165,
+      "lines_removed": 2,
+      "files_changed": 2
+    },
+    "errors": {
+      "test_failures": 0,
+      "fix_attempts": 0
+    },
+    "saturation": {
+      "backlog_remaining": 6
+    }
+  }
+}

--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -35,7 +35,7 @@ _DEFAULT_DEPARTURE = "서울(ICN)"  # default origin for flight search
 
 
 class Intent(BaseModel):
-    action: str  # create_plan | confirm_plan | modify_day | refine_plan | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | delete_plan | view_plan | add_expense | update_expense | update_plan | get_expense_summary | delete_expense | list_expenses | copy_plan | get_weather | reset_conversation | add_day_note | suggest_improvements | remove_place | add_place | share_plan | reorder_days | clear_day | duplicate_day | move_place | set_day_label | quick_summary | swap_places | general
+    action: str  # create_plan | confirm_plan | modify_day | refine_plan | search_places | search_hotels | search_flights | save_plan | export_calendar | list_plans | delete_plan | view_plan | add_expense | update_expense | update_plan | get_expense_summary | delete_expense | list_expenses | copy_plan | get_weather | reset_conversation | add_day_note | suggest_improvements | remove_place | add_place | share_plan | reorder_days | clear_day | duplicate_day | move_place | set_day_label | quick_summary | swap_places | find_alternatives | general
     destination: Optional[str] = None
     start_date: Optional[str] = None
     end_date: Optional[str] = None
@@ -189,7 +189,7 @@ The user is based in South Korea. Budget values should be in KRW (Korean Won). D
 User message: "{message}"
 
 Return a JSON object with these fields:
-- action: one of "create_plan", "confirm_plan", "modify_day", "refine_plan", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "add_expense", "update_expense", "update_plan", "get_expense_summary", "delete_expense", "list_expenses", "copy_plan", "get_weather", "reset_conversation", "add_day_note", "suggest_improvements", "remove_place", "add_place", "share_plan", "reorder_days", "clear_day", "duplicate_day", "move_place", "set_day_label", "quick_summary", "swap_places", "general"
+- action: one of "create_plan", "confirm_plan", "modify_day", "refine_plan", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "add_expense", "update_expense", "update_plan", "get_expense_summary", "delete_expense", "list_expenses", "copy_plan", "get_weather", "reset_conversation", "add_day_note", "suggest_improvements", "remove_place", "add_place", "share_plan", "reorder_days", "clear_day", "duplicate_day", "move_place", "set_day_label", "quick_summary", "swap_places", "find_alternatives", "general"
 - Use action "confirm_plan" when the user confirms they want to proceed with creating a travel plan (e.g. "네 세워줘", "좋아 계획해줘", "응 진행해", "yes please", "go ahead", "확인")
 - IMPORTANT: Use action "general" for casual conversation, questions, opinions, or when the user is discussing/exploring options but NOT explicitly requesting to create or modify a plan. Examples: "후쿠오카 4박 5일은 너무 길지 않을까?" → general (asking opinion), "여행지 추천해줘" → general (asking for suggestions), "벌레 싫은데" → general (sharing preference)
 - Use "create_plan" ONLY when the user explicitly asks to CREATE a plan with specific details. Use "refine_plan" ONLY when the user explicitly asks to CHANGE an existing plan (e.g. "일정 수정해줘", "3일차 바꿔줘")
@@ -226,6 +226,7 @@ Return a JSON object with these fields:
 - Use action "set_day_label" when user wants to give a custom title/label/name to a specific day (e.g. "1일차 이름을 '미식 투어'로 해줘", "Day 2 제목을 '자연 탐방'으로 설정해줘", "3일차 이름 바꿔줘, '쇼핑 데이'로", "set day 1 label to 'Food Tour'", "name day 3 'Beach Day'", "Day 2 타이틀을 '박물관 투어'로 해줘"); set day_number to the referenced day and query to the label text
 - Use action "quick_summary" when user wants a concise overview or summary of the current travel plan (e.g. "현재 일정 요약해줘", "일정 요약", "여행 계획 요약", "지금 계획 어때?", "summary of my trip", "what's my itinerary?", "계획 개요", "trip overview", "현재 일정 간단히 알려줘")
 - Use action "swap_places" when user wants to swap/exchange a specific place from one day with a specific place from another day (e.g. "1일차 첫 번째 장소와 2일차 두 번째 장소 바꿔줘", "Day 1 두 번째와 Day 3 첫 번째 장소 교환해줘", "swap day 1 place 1 with day 2 place 2", "1일차 센소지를 2일차 시부야와 바꿔줘"); set day_number to the first day, day_number_2 to the second day, place_index to the 1-based index of the place in the first day (default 1), and place_index_2 to the 1-based index of the place in the second day (default 1)
+- Use action "find_alternatives" when user wants to find alternative/replacement places for a specific slot in their itinerary (e.g. "1일차 첫 번째 장소 대신 다른 곳 추천해줘", "Day 2 두 번째 장소 대체 장소 찾아줘", "센소지 대신 갈 곳 알려줘", "suggest alternatives for day 1 place 2", "1일차 두 번째 장소 바꿀 곳 추천", "대체 장소 찾아줘", "다른 곳 추천해줘"); set day_number to the referenced day (default 1), place_index to the 1-based position if mentioned, query to the place name to replace if mentioned, and place_category to the preferred category if mentioned
 - raw_message: the exact original message"""
 
             client = genai.Client(api_key=self._api_key)
@@ -434,6 +435,9 @@ Return a JSON object with these fields:
                 yield _track_and_collect(event)
         elif intent.action == "swap_places":
             async for event in self._handle_swap_places(intent, session, db):
+                yield _track_and_collect(event)
+        elif intent.action == "find_alternatives":
+            async for event in self._handle_find_alternatives(intent, session):
                 yield _track_and_collect(event)
         else:  # general
             async for event in self._handle_general(intent, session):
@@ -3470,6 +3474,123 @@ Return a JSON object with these fields:
             yield {
                 "type": "chat_chunk",
                 "data": {"text": "장소를 교환하려면 먼저 여행 계획을 만들거나 저장해주세요."},
+            }
+
+    async def _handle_find_alternatives(
+        self,
+        intent: Intent,
+        session: "ChatSession",
+    ) -> AsyncGenerator[dict, None]:
+        """Search for alternative replacement places for a specific itinerary slot.
+
+        Uses day_number + place_index (1-based) to identify the target slot and
+        optionally query (place name) / place_category to narrow the search.
+        Falls back to a helpful message when no destination is known.
+
+        Emits: place_scout working→done, search_results (type=alternatives), chat_chunk.
+        """
+        day_number = intent.day_number or 1
+        place_idx = intent.place_index  # 1-based, may be None
+        place_name_hint = intent.query or ""
+        category = intent.place_category or ""
+
+        # Resolve destination from intent or session plan
+        destination = intent.destination
+        if not destination and session.last_plan:
+            destination = session.last_plan.get("destination") or ""
+        destination = destination or ""
+
+        yield {
+            "type": "agent_status",
+            "data": {
+                "agent": "place_scout",
+                "status": "working",
+                "message": f"{destination or '목적지'} 대체 장소 검색 중...",
+            },
+        }
+        await asyncio.sleep(0)
+
+        # If no destination is known, we cannot search
+        if not destination:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "place_scout", "status": "done", "message": "목적지 정보 없음"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": "대체 장소를 찾으려면 여행 계획을 먼저 만들거나 목적지를 알려주세요."},
+            }
+            return
+
+        # Determine the current place name from session plan for context
+        current_place = place_name_hint
+        if not current_place and session.last_plan:
+            days = session.last_plan.get("days", [])
+            day_idx = day_number - 1
+            if 0 <= day_idx < len(days):
+                places = days[day_idx].get("places", [])
+                if place_idx and 1 <= place_idx <= len(places):
+                    current_place = places[place_idx - 1].get("name", "")
+
+        # Build interests/query string for search
+        if current_place:
+            interests = f"{category} 대체 추천 (replacing {current_place})" if category else f"{current_place} 대체 장소 추천"
+        else:
+            interests = f"{category} 추천 장소" if category else "관광지 추천"
+
+        try:
+            result = await asyncio.to_thread(
+                self._web_search.search_places,
+                destination,
+                interests,
+                category,
+            )
+
+            place_count = len(result.places)
+            yield {
+                "type": "agent_status",
+                "data": {
+                    "agent": "place_scout",
+                    "status": "done",
+                    "message": f"{place_count}개 대체 장소 찾음",
+                    "result_count": place_count,
+                },
+            }
+
+            results_data = result.model_dump()
+            results_data["for_place"] = current_place
+            results_data["day_number"] = day_number
+            results_data["place_index"] = place_idx
+
+            yield {
+                "type": "search_results",
+                "data": {"type": "alternatives", "results": results_data},
+            }
+
+            if current_place:
+                chat_text = (
+                    f"Day {day_number}의 '{current_place}' 대신 방문할 수 있는 "
+                    f"{destination} 장소 {place_count}개를 찾았습니다."
+                )
+            else:
+                chat_text = f"Day {day_number}에 추천할 {destination} 장소 {place_count}개를 찾았습니다."
+
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": chat_text},
+            }
+
+        except Exception as exc:
+            logger.error(
+                "_handle_find_alternatives: failed — %s: %s", type(exc).__name__, exc, exc_info=True
+            )
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "place_scout", "status": "error", "message": "대체 장소 검색 실패"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"대체 장소 검색 중 오류가 발생했습니다: {exc}"},
             }
 
     async def _handle_get_weather(

--- a/status.md
+++ b/status.md
@@ -1,20 +1,20 @@
 # Status
 
-Last run: 2026-04-07T23:00:00Z (Evolve Run #132)
-Run count: 163
+Last run: 2026-04-07T21:27:29Z (Evolve Run #133)
+Run count: 164
 Phase: Phase 10: Chat + Multi-Agent Dashboard
 Health: GREEN
 Error Budget: HEALTHY
-Tasks completed: 108 (#107 Chat: swap_places intent — bidirectional place swap between days; day_update SSE for both days; 12 new tests; 1623/1623 tests passing)
-Current focus: #108 Chat: find_alternatives intent
-Next planned: #109 E2E: set_day_label + day label display Playwright scenarios
+Tasks completed: 109 (#108 Chat: find_alternatives intent — place_scout agent_status + search_results SSE with alternatives; 7 new tests; 1630/1630 tests passing)
+Current focus: #109 E2E: set_day_label + day label display Playwright scenarios
+Next planned: #110 E2E: find_alternatives Playwright scenarios
 
 ## LTES Snapshot
 
-- Latency: ~56000ms (monitor run)
-- Traffic: 29 commits (last 24h)
-- Errors: 0 test failures (1611 passed, 12 skipped), error_rate=0.0%
-- Saturation: 2 tasks ready (#108, #109)
+- Latency: ~50000ms (evolve run)
+- Traffic: 1 commit (this run)
+- Errors: 0 test failures (1630 passed, 12 skipped), error_rate=0.0%
+- Saturation: 6 tasks ready (#109–#114)
 
 ## Phase Transition
 
@@ -29,6 +29,15 @@ Next planned: #109 E2E: set_day_label + day label display Playwright scenarios
   - Evolve: 5 specialized agents (Coordinator, Architect, Builder, QA, Reporter)
 
 ## Recent Changes
+
+### Evolve Run #133 — 2026-04-07T21:27:29Z
+- **Task**: #108 - Chat: `find_alternatives` intent — suggest replacement places for a slot [feature]
+- **Result**: GREEN ✓ (QA pass)
+- **Tests**: 1630/1630 passed, 12 skipped; 7 new tests added (TestFindAlternativesHandler: intent model, happy path, place_scout activation, no-plan+no-destination fallback, no-plan+destination-in-intent, chat_done last, search error)
+- **Files changed**: src/app/chat.py, tests/test_chat.py (+165/-2)
+- **Builder note**: Implemented find_alternatives intent. Handler uses place_scout agent to search for replacement places for a specific day slot. Resolves destination from session.last_plan if not in intent. Emits agent_status (working→done with result_count) + search_results (type=alternatives, includes for_place/day_number/place_index context) + chat_chunk. Graceful no-plan/no-destination fallback without searching.
+- **LTES**: L=50000ms T=1 commit E=0 test failures S=6 tasks remaining
+- **Agents**: coordinator ✓ → architect ✓ → builder ✓ → qa ✓ → reporter ✓
 
 ### Evolve Run #132 — 2026-04-07T23:00:00Z
 - **Task**: #107 - Chat: `swap_places` intent — swap places between two days [feature]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -9031,3 +9031,251 @@ class TestSwapPlacesHandler:
         finally:
             db.close()
             Base.metadata.drop_all(bind=engine)
+
+
+# Task #108: find_alternatives intent handler
+# done_criteria: search_results SSE with alternatives; agent_status for place_scout;
+#                2+ tests (happy path, no-plan fallback)
+
+class TestFindAlternativesHandler:
+    """_handle_find_alternatives: search replacement places for a specific day slot."""
+
+    # ------------------------------------------------------------------
+    # Intent model acceptance
+    # ------------------------------------------------------------------
+
+    def test_find_alternatives_intent_accepted_by_model(self):
+        """Intent model must accept find_alternatives action."""
+        from app.chat import Intent
+        intent = Intent(
+            action="find_alternatives",
+            day_number=1,
+            place_index=2,
+            query="센소지",
+            place_category="sightseeing",
+            raw_message="1일차 두 번째 장소 대체 추천해줘",
+        )
+        assert intent.action == "find_alternatives"
+        assert intent.day_number == 1
+        assert intent.place_index == 2
+        assert intent.query == "센소지"
+        assert intent.place_category == "sightseeing"
+
+    # ------------------------------------------------------------------
+    # Happy path: session has a plan with matching place
+    # ------------------------------------------------------------------
+
+    def test_find_alternatives_happy_path_emits_search_results(self):
+        """find_alternatives with a plan emits place_scout working/done + search_results."""
+        from app.web_search import DestinationSearchResult, PlaceSearchResult
+
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "도쿄",
+            "days": [
+                {
+                    "day_number": 1,
+                    "date": "2026-05-01",
+                    "places": [
+                        {"name": "센소지", "category": "sightseeing"},
+                        {"name": "아키하바라", "category": "shopping"},
+                    ],
+                },
+            ],
+        }
+
+        mock_result = DestinationSearchResult(
+            destination="도쿄",
+            query="도쿄 아키하바라 대체 장소 추천",
+            places=[
+                PlaceSearchResult(name="시부야 스카이", category="sightseeing", description="전망대"),
+                PlaceSearchResult(name="오다이바", category="sightseeing", description="해변 공원"),
+                PlaceSearchResult(name="우에노 공원", category="park", description="공원"),
+            ],
+            summary="도쿄 주요 관광지",
+        )
+
+        with patch.object(svc._web_search, "search_places", return_value=mock_result), \
+             patch.object(svc, "extract_intent", return_value=Intent(
+                 action="find_alternatives",
+                 day_number=1,
+                 place_index=2,
+                 raw_message="1일차 두 번째 장소 대체 추천해줘",
+             )):
+            events = _collect_events(svc, session.session_id, "1일차 두 번째 장소 대체 추천해줘")
+
+        # place_scout must go working → done
+        agent_events = [e for e in events if e["type"] == "agent_status" and e["data"]["agent"] == "place_scout"]
+        statuses = [e["data"]["status"] for e in agent_events]
+        assert "working" in statuses
+        assert "done" in statuses
+
+        # done event must include result_count
+        done_event = next(e for e in agent_events if e["data"]["status"] == "done")
+        assert done_event["data"].get("result_count") == 3
+
+        # search_results event must be emitted with type=alternatives
+        search_events = [e for e in events if e["type"] == "search_results"]
+        assert len(search_events) == 1
+        sr = search_events[0]
+        assert sr["data"]["type"] == "alternatives"
+        assert len(sr["data"]["results"]["places"]) == 3
+
+        # results must carry context fields
+        results_data = sr["data"]["results"]
+        assert results_data["for_place"] == "아키하바라"
+        assert results_data["day_number"] == 1
+        assert results_data["place_index"] == 2
+
+        # chat_chunk must mention the day and the replaced place
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        combined = " ".join(e["data"]["text"] for e in chat_chunks)
+        assert "Day 1" in combined or "1" in combined
+        assert "아키하바라" in combined
+
+        # must end with chat_done
+        assert events[-1]["type"] == "chat_done"
+
+    def test_find_alternatives_activates_place_scout_agent(self):
+        """find_alternatives must emit place_scout agent_status events."""
+        from app.web_search import DestinationSearchResult
+
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "파리",
+            "days": [
+                {"day_number": 1, "date": "2026-06-01", "places": [
+                    {"name": "에펠탑", "category": "landmark"},
+                ]},
+            ],
+        }
+
+        mock_result = DestinationSearchResult(
+            destination="파리",
+            query="에펠탑 대체",
+            places=[{"name": "루브르 박물관", "category": "museum", "description": "세계적 박물관", "address": "", "tips": ""}],
+            summary="파리 명소",
+        )
+
+        with patch.object(svc._web_search, "search_places", return_value=mock_result), \
+             patch.object(svc, "extract_intent", return_value=Intent(
+                 action="find_alternatives",
+                 day_number=1,
+                 place_index=1,
+                 raw_message="에펠탑 대신 갈 곳 추천해줘",
+             )):
+            events = _collect_events(svc, session.session_id, "에펠탑 대신 갈 곳 추천해줘")
+
+        agent_events = [e for e in events if e["type"] == "agent_status"]
+        place_scout_events = [e for e in agent_events if e["data"]["agent"] == "place_scout"]
+        assert len(place_scout_events) >= 2
+
+    # ------------------------------------------------------------------
+    # No-plan fallback
+    # ------------------------------------------------------------------
+
+    def test_find_alternatives_no_plan_no_destination_emits_helpful_message(self):
+        """find_alternatives with no plan and no destination emits a helpful chat_chunk, no search call."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        # No last_plan set
+
+        with patch.object(svc._web_search, "search_places") as mock_search, \
+             patch.object(svc, "extract_intent", return_value=Intent(
+                 action="find_alternatives",
+                 day_number=1,
+                 raw_message="대체 장소 찾아줘",
+             )):
+            events = _collect_events(svc, session.session_id, "대체 장소 찾아줘")
+
+        # search_places must NOT be called when there's no destination
+        mock_search.assert_not_called()
+
+        # No search_results event
+        search_events = [e for e in events if e["type"] == "search_results"]
+        assert len(search_events) == 0
+
+        # A chat_chunk with a helpful message must be present
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        assert len(chat_chunks) >= 1
+        combined = " ".join(e["data"]["text"] for e in chat_chunks)
+        assert len(combined) > 10  # non-empty helpful text
+
+        # place_scout done (not error) for a graceful fallback
+        agent_events = [e for e in events if e["type"] == "agent_status" and e["data"]["agent"] == "place_scout"]
+        statuses = [e["data"]["status"] for e in agent_events]
+        assert "error" not in statuses
+
+        assert events[-1]["type"] == "chat_done"
+
+    def test_find_alternatives_no_plan_but_destination_in_intent_searches(self):
+        """find_alternatives with no plan but destination in intent proceeds with search."""
+        from app.web_search import DestinationSearchResult
+
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        # No last_plan, but intent carries destination
+
+        mock_result = DestinationSearchResult(
+            destination="오사카",
+            query="오사카 맛집 추천",
+            places=[
+                {"name": "도톤보리", "category": "food", "description": "유명 맛집 거리", "address": "", "tips": ""},
+                {"name": "구로몬 시장", "category": "food", "description": "신선한 식재료", "address": "", "tips": ""},
+            ],
+            summary="오사카 맛집",
+        )
+
+        with patch.object(svc._web_search, "search_places", return_value=mock_result), \
+             patch.object(svc, "extract_intent", return_value=Intent(
+                 action="find_alternatives",
+                 destination="오사카",
+                 day_number=2,
+                 place_category="food",
+                 raw_message="2일차 맛집 대체 추천해줘",
+             )):
+            events = _collect_events(svc, session.session_id, "2일차 맛집 대체 추천해줘")
+
+        search_events = [e for e in events if e["type"] == "search_results"]
+        assert len(search_events) == 1
+        assert search_events[0]["data"]["type"] == "alternatives"
+        assert len(search_events[0]["data"]["results"]["places"]) == 2
+
+        assert events[-1]["type"] == "chat_done"
+
+    def test_find_alternatives_chat_done_is_last_event(self):
+        """find_alternatives always ends with chat_done regardless of path."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+            action="find_alternatives",
+            raw_message="대체 추천해줘",
+        )):
+            events = _collect_events(svc, session.session_id, "대체 추천해줘")
+
+        assert events[-1]["type"] == "chat_done"
+
+    def test_find_alternatives_search_error_emits_error_status(self):
+        """find_alternatives emits place_scout error on search failure."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "도쿄",
+            "days": [{"day_number": 1, "date": "2026-05-01", "places": [{"name": "센소지"}]}],
+        }
+
+        with patch.object(svc._web_search, "search_places", side_effect=RuntimeError("API timeout")), \
+             patch.object(svc, "extract_intent", return_value=Intent(
+                 action="find_alternatives",
+                 day_number=1,
+                 place_index=1,
+                 raw_message="대체 장소 추천해줘",
+             )):
+            events = _collect_events(svc, session.session_id, "대체 장소 추천해줘")
+
+        agent_events = [e for e in events if e["type"] == "agent_status" and e["data"]["agent"] == "place_scout"]
+        assert any(e["data"]["status"] == "error" for e in agent_events)
+        assert events[-1]["type"] == "chat_done"


### PR DESCRIPTION
## Evolve Run #133
- **Phase**: Phase 10: Chat + Multi-Agent Dashboard
- **Health**: GREEN
- **Task**: #108 - Chat: `find_alternatives` intent — suggest replacement places for a slot
- **QA**: pass
- **Tests**: 1630/1630 passed (12 skipped)

Closes #171

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Selected task #108; needs_architect=true; health=GREEN |
| 📐 Architect | ✅ | Spec reviewed from markdowns/feat-chat-dashboard.md |
| 🔨 Builder | ✅ | src/app/chat.py, tests/test_chat.py (+165/-2); 7 new tests |
| 🧪 QA | ✅ | All checks pass; 1630 passed, 12 skipped; no regressions |
| 📝 Reporter | ✅ | This PR |

### Changes
- `find_alternatives` intent handler added to ChatService
- Uses `place_scout` agent — emits `agent_status` (working→done with result_count)
- Emits `search_results` SSE with `type=alternatives` including `for_place`, `day_number`, `place_index` context fields
- Emits `chat_chunk` with summary of found alternatives
- Graceful fallback when no plan/destination in session (no search call)
- Resolves destination from `session.last_plan` if not in intent

🤖 Auto-generated by Evolve Pipeline