### PR TITLE
feature: #163 Chat find_nearby intent — search places near a plan location

### DIFF
--- a/src/app/chat.py
+++ b/src/app/chat.py
@@ -189,7 +189,7 @@ The user is based in South Korea. Budget values should be in KRW (Korean Won). D
 User message: "{message}"
 
 Return a JSON object with these fields:
-- action: one of "create_plan", "confirm_plan", "modify_day", "refine_plan", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "add_expense", "update_expense", "update_plan", "get_expense_summary", "delete_expense", "list_expenses", "copy_plan", "get_weather", "reset_conversation", "add_day_note", "suggest_improvements", "remove_place", "add_place", "share_plan", "reorder_days", "clear_day", "duplicate_day", "move_place", "set_day_label", "quick_summary", "swap_places", "find_alternatives", "general"
+- action: one of "create_plan", "confirm_plan", "modify_day", "refine_plan", "search_places", "search_hotels", "search_flights", "save_plan", "list_plans", "delete_plan", "view_plan", "add_expense", "update_expense", "update_plan", "get_expense_summary", "delete_expense", "list_expenses", "copy_plan", "get_weather", "reset_conversation", "add_day_note", "suggest_improvements", "remove_place", "add_place", "share_plan", "reorder_days", "clear_day", "duplicate_day", "move_place", "set_day_label", "quick_summary", "swap_places", "find_alternatives", "find_nearby", "general"
 - Use action "confirm_plan" when the user confirms they want to proceed with creating a travel plan (e.g. "네 세워줘", "좋아 계획해줘", "응 진행해", "yes please", "go ahead", "확인")
 - IMPORTANT: Use action "general" for casual conversation, questions, opinions, or when the user is discussing/exploring options but NOT explicitly requesting to create or modify a plan. Examples: "후쿠오카 4박 5일은 너무 길지 않을까?" → general (asking opinion), "여행지 추천해줘" → general (asking for suggestions), "벌레 싫은데" → general (sharing preference)
 - Use "create_plan" ONLY when the user explicitly asks to CREATE a plan with specific details. Use "refine_plan" ONLY when the user explicitly asks to CHANGE an existing plan (e.g. "일정 수정해줘", "3일차 바꿔줘")
@@ -227,6 +227,7 @@ Return a JSON object with these fields:
 - Use action "quick_summary" when user wants a concise overview or summary of the current travel plan (e.g. "현재 일정 요약해줘", "일정 요약", "여행 계획 요약", "지금 계획 어때?", "summary of my trip", "what's my itinerary?", "계획 개요", "trip overview", "현재 일정 간단히 알려줘")
 - Use action "swap_places" when user wants to swap/exchange a specific place from one day with a specific place from another day (e.g. "1일차 첫 번째 장소와 2일차 두 번째 장소 바꿔줘", "Day 1 두 번째와 Day 3 첫 번째 장소 교환해줘", "swap day 1 place 1 with day 2 place 2", "1일차 센소지를 2일차 시부야와 바꿔줘"); set day_number to the first day, day_number_2 to the second day, place_index to the 1-based index of the place in the first day (default 1), and place_index_2 to the 1-based index of the place in the second day (default 1)
 - Use action "find_alternatives" when user wants to find alternative/replacement places for a specific slot in their itinerary (e.g. "1일차 첫 번째 장소 대신 다른 곳 추천해줘", "Day 2 두 번째 장소 대체 장소 찾아줘", "센소지 대신 갈 곳 알려줘", "suggest alternatives for day 1 place 2", "1일차 두 번째 장소 바꿀 곳 추천", "대체 장소 찾아줘", "다른 곳 추천해줘"); set day_number to the referenced day (default 1), place_index to the 1-based position if mentioned, query to the place name to replace if mentioned, and place_category to the preferred category if mentioned
+- Use action "find_nearby" when user wants to find places near a specific location or near a place in the current plan (e.g. "센소지 근처 카페 찾아줘", "1일차 첫 번째 장소 근처 맛집", "시부야 근처 관광지", "find cafes near Senso-ji", "1일차 근처 맛집 추천해줘", "호텔 근처 편의점"); set day_number to the referenced day if mentioned, place_index to the 1-based position if mentioned, query to the location/place name, and place_category to the desired category if mentioned (e.g. "카페" → "cafe", "맛집" → "food", "관광지" → "sightseeing")
 - raw_message: the exact original message"""
 
             client = genai.Client(api_key=self._api_key)
@@ -438,6 +439,9 @@ Return a JSON object with these fields:
                 yield _track_and_collect(event)
         elif intent.action == "find_alternatives":
             async for event in self._handle_find_alternatives(intent, session):
+                yield _track_and_collect(event)
+        elif intent.action == "find_nearby":
+            async for event in self._handle_find_nearby(intent, session):
                 yield _track_and_collect(event)
         else:  # general
             async for event in self._handle_general(intent, session):
@@ -3591,6 +3595,120 @@ Return a JSON object with these fields:
             yield {
                 "type": "chat_chunk",
                 "data": {"text": f"대체 장소 검색 중 오류가 발생했습니다: {exc}"},
+            }
+
+    async def _handle_find_nearby(
+        self,
+        intent: Intent,
+        session: "ChatSession",
+    ) -> AsyncGenerator[dict, None]:
+        """Search for places near a specific location or plan place.
+
+        Uses query (location name), day_number + place_index to resolve reference
+        location from the current plan. Falls back when no plan/destination exists.
+
+        Emits: place_scout working→done, search_results (type=nearby), chat_chunk.
+        """
+        location_hint = intent.query or ""
+        day_number = intent.day_number
+        place_idx = intent.place_index
+        category = intent.place_category or ""
+
+        # Resolve destination from intent or session plan
+        destination = intent.destination
+        if not destination and session.last_plan:
+            destination = session.last_plan.get("destination") or ""
+        destination = destination or ""
+
+        yield {
+            "type": "agent_status",
+            "data": {
+                "agent": "place_scout",
+                "status": "working",
+                "message": f"{location_hint or destination or '장소'} 근처 검색 중...",
+            },
+        }
+        await asyncio.sleep(0)
+
+        # If no destination and no location hint, we cannot search
+        if not destination and not location_hint:
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "place_scout", "status": "done", "message": "위치 정보 없음"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": "근처 장소를 찾으려면 여행 계획을 먼저 만들거나 위치를 알려주세요."},
+            }
+            return
+
+        # Resolve reference place name from session plan if day/index given
+        ref_place = location_hint
+        if not ref_place and session.last_plan and day_number:
+            days = session.last_plan.get("days", [])
+            day_idx = day_number - 1
+            if 0 <= day_idx < len(days):
+                places = days[day_idx].get("places", [])
+                if place_idx and 1 <= place_idx <= len(places):
+                    ref_place = places[place_idx - 1].get("name", "")
+                elif places:
+                    ref_place = places[0].get("name", "")
+
+        # Build search query
+        search_location = ref_place or destination
+        if category:
+            interests = f"{search_location} 근처 {category}"
+        else:
+            interests = f"{search_location} 근처 추천 장소"
+
+        try:
+            result = await asyncio.to_thread(
+                self._web_search.search_places,
+                destination or search_location,
+                interests,
+                category,
+            )
+
+            place_count = len(result.places)
+            yield {
+                "type": "agent_status",
+                "data": {
+                    "agent": "place_scout",
+                    "status": "done",
+                    "message": f"{place_count}개 근처 장소 찾음",
+                    "result_count": place_count,
+                },
+            }
+
+            results_data = result.model_dump()
+            results_data["near_place"] = ref_place
+            results_data["day_number"] = day_number
+
+            yield {
+                "type": "search_results",
+                "data": {"type": "nearby", "results": results_data},
+            }
+
+            chat_text = f"'{search_location}' 근처에서 {place_count}개의 장소를 찾았습니다."
+            if category:
+                chat_text = f"'{search_location}' 근처 {category} {place_count}개를 찾았습니다."
+
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": chat_text},
+            }
+
+        except Exception as exc:
+            logger.error(
+                "_handle_find_nearby: failed — %s: %s", type(exc).__name__, exc, exc_info=True
+            )
+            yield {
+                "type": "agent_status",
+                "data": {"agent": "place_scout", "status": "error", "message": "근처 장소 검색 실패"},
+            }
+            yield {
+                "type": "chat_chunk",
+                "data": {"text": f"근처 장소 검색 중 오류가 발생했습니다: {exc}"},
             }
 
     async def _handle_get_weather(

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -9279,3 +9279,178 @@ class TestFindAlternativesHandler:
         agent_events = [e for e in events if e["type"] == "agent_status" and e["data"]["agent"] == "place_scout"]
         assert any(e["data"]["status"] == "error" for e in agent_events)
         assert events[-1]["type"] == "chat_done"
+
+
+# ---------------------------------------------------------------------------
+# find_nearby intent handler (Issue #163)
+# ---------------------------------------------------------------------------
+
+
+class TestFindNearbyHandler:
+    """_handle_find_nearby: search for places near a location or plan place."""
+
+    # ------------------------------------------------------------------
+    # Intent model acceptance
+    # ------------------------------------------------------------------
+
+    def test_find_nearby_intent_accepted_by_model(self):
+        """Intent model must accept find_nearby action."""
+        intent = Intent(
+            action="find_nearby",
+            query="센소지",
+            place_category="cafe",
+            day_number=1,
+            place_index=1,
+            raw_message="센소지 근처 카페 찾아줘",
+        )
+        assert intent.action == "find_nearby"
+        assert intent.query == "센소지"
+        assert intent.place_category == "cafe"
+
+    # ------------------------------------------------------------------
+    # Happy path: session has a plan, search by location name
+    # ------------------------------------------------------------------
+
+    def test_find_nearby_happy_path_emits_search_results(self):
+        """find_nearby with a plan emits place_scout working/done + search_results(type=nearby)."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "도쿄",
+            "days": [
+                {
+                    "day_number": 1,
+                    "date": "2026-05-01",
+                    "places": [
+                        {"name": "센소지", "category": "sightseeing"},
+                        {"name": "아키하바라", "category": "shopping"},
+                    ],
+                },
+            ],
+        }
+
+        mock_result = DestinationSearchResult(
+            destination="도쿄",
+            query="센소지 근처 cafe",
+            places=[
+                PlaceSearchResult(name="카미나리몬 카페", category="cafe", description="전통 카페"),
+                PlaceSearchResult(name="아사쿠사 로스터리", category="cafe", description="스페셜티 커피"),
+            ],
+            summary="센소지 근처 카페",
+        )
+
+        with patch.object(svc._web_search, "search_places", return_value=mock_result), \
+             patch.object(svc, "extract_intent", return_value=Intent(
+                 action="find_nearby",
+                 query="센소지",
+                 place_category="cafe",
+                 raw_message="센소지 근처 카페 찾아줘",
+             )):
+            events = _collect_events(svc, session.session_id, "센소지 근처 카페 찾아줘")
+
+        # place_scout must go working → done
+        agent_events = [e for e in events if e["type"] == "agent_status" and e["data"]["agent"] == "place_scout"]
+        statuses = [e["data"]["status"] for e in agent_events]
+        assert "working" in statuses
+        assert "done" in statuses
+
+        # done event must include result_count
+        done_event = next(e for e in agent_events if e["data"]["status"] == "done")
+        assert done_event["data"].get("result_count") == 2
+
+        # search_results event must be emitted with type=nearby
+        search_events = [e for e in events if e["type"] == "search_results"]
+        assert len(search_events) == 1
+        sr = search_events[0]
+        assert sr["data"]["type"] == "nearby"
+        assert len(sr["data"]["results"]["places"]) == 2
+
+        # results must carry context field
+        results_data = sr["data"]["results"]
+        assert results_data["near_place"] == "센소지"
+
+        # chat_chunk must mention the location
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        combined = " ".join(e["data"]["text"] for e in chat_chunks)
+        assert "센소지" in combined
+        assert "2" in combined  # place count
+
+        assert events[-1]["type"] == "chat_done"
+
+    # ------------------------------------------------------------------
+    # No plan / no destination fallback
+    # ------------------------------------------------------------------
+
+    def test_find_nearby_no_plan_fallback(self):
+        """find_nearby with no plan and no query emits fallback message."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        # No plan, no query, no destination
+
+        with patch.object(svc, "extract_intent", return_value=Intent(
+                action="find_nearby",
+                raw_message="근처 맛집 추천해줘",
+             )):
+            events = _collect_events(svc, session.session_id, "근처 맛집 추천해줘")
+
+        # Should get a fallback chat message
+        chat_chunks = [e for e in events if e["type"] == "chat_chunk"]
+        combined = " ".join(e["data"]["text"] for e in chat_chunks)
+        assert "여행 계획" in combined or "위치" in combined
+
+        # place_scout should end in done (not error)
+        agent_events = [e for e in events if e["type"] == "agent_status" and e["data"]["agent"] == "place_scout"]
+        assert any(e["data"]["status"] == "done" for e in agent_events)
+
+        assert events[-1]["type"] == "chat_done"
+
+    # ------------------------------------------------------------------
+    # Day/place reference resolution from plan
+    # ------------------------------------------------------------------
+
+    def test_find_nearby_resolves_place_from_plan_day(self):
+        """find_nearby with day_number resolves the place name from plan."""
+        svc = _make_service_no_api()
+        session = svc.create_session()
+        session.last_plan = {
+            "destination": "파리",
+            "days": [
+                {
+                    "day_number": 1,
+                    "date": "2026-06-01",
+                    "places": [
+                        {"name": "에펠탑", "category": "landmark"},
+                        {"name": "루브르 박물관", "category": "museum"},
+                    ],
+                },
+            ],
+        }
+
+        mock_result = DestinationSearchResult(
+            destination="파리",
+            query="루브르 박물관 근처 추천 장소",
+            places=[
+                PlaceSearchResult(name="튈르리 정원", category="park", description="공원"),
+            ],
+            summary="루브르 근처",
+        )
+
+        with patch.object(svc._web_search, "search_places", return_value=mock_result) as mock_search, \
+             patch.object(svc, "extract_intent", return_value=Intent(
+                 action="find_nearby",
+                 day_number=1,
+                 place_index=2,
+                 raw_message="1일차 두 번째 장소 근처 맛집",
+             )):
+            events = _collect_events(svc, session.session_id, "1일차 두 번째 장소 근처 맛집")
+
+        # search_places should have been called with 루브르 박물관 context
+        mock_search.assert_called_once()
+        call_args = mock_search.call_args
+        # interests arg should reference 루브르 박물관
+        assert "루브르 박물관" in call_args[0][1]
+
+        # search_results near_place should be resolved
+        search_events = [e for e in events if e["type"] == "search_results"]
+        assert len(search_events) == 1
+        assert search_events[0]["data"]["results"]["near_place"] == "루브르 박물관"


### PR DESCRIPTION
## Evolve Run #2026-04-08-local
- **Phase**: Phase 10
- **Health**: GREEN
- **Task**: #163 Chat: find_nearby intent — search places near a plan location
- **QA**: pass
- **Tests**: 1634/1634 passed (4 new)

Closes #163

### Agent Activity
| Agent | Status | Detail |
|-------|--------|--------|
| 🧠 Coordinator | ✅ | Issues cache generated (10 ready), selected #163, label ready→in-progress |
| 📐 Architect | ⏭️ | Skipped (ready=10) |
| 🔨 Builder | ✅ | src/app/chat.py, tests/test_chat.py (+294 lines) |
| 🧪 QA | ✅ | 1634 passed, lint clean, done criteria met |
| 📝 Reporter | ✅ | Issue #163 closed, backlog.md snapshot regenerated, state→main, this PR |

### First evolve run with new harness architecture
- ✅ GitHub Issues as source of truth (no backlog.md writes by Coordinator/Architect)
- ✅ Coordinator generated `.evolve/backlog.json` cache from `gh issue list`
- ✅ Issue label transition: `ready` → `in-progress` → closed
- ✅ Reporter two-phase commit: state→main, code→branch PR
- ✅ backlog.md regenerated as read-only snapshot from Issues

🤖 Auto-generated by Evolve Pipeline