### PR TITLE
refactor: harness engineering improvements — timeouts, retry loop, OpenChrome

### DIFF
--- a/.claude/agents/coordinator.md
+++ b/.claude/agents/coordinator.md
@@ -127,11 +127,19 @@ pytest tests/ -v --tb=short 2>&1 || true
 - `.evolve/backlog.json`의 `ready_count`가 **2개 이하**이면 → `needs_architect: true`
 - 충분하면 → `needs_architect: false`
 
-### 4. 태스크 선택 (with idempotency check)
+### 4. 태스크 선택 (with idempotency check + failure history)
 `.evolve/backlog.json`에서 태스크를 선택한다:
 
 1. `in_progress`가 있으면 → 그 태스크 (이전 run에서 이어서)
 2. 없으면 → `ready` 목록에서 우선순위 최상위 (번호가 낮은 것)
+
+**Per-issue failure check**: 선택 전 `error-budget.json`의 `issue_failure_history`를 확인한다.
+해당 이슈의 `attempts >= 3`이면 → 자동 blocked 처리하고 다음 ready 태스크로 skip:
+```bash
+gh issue edit <number> --remove-label "ready" --add-label "blocked"
+gh issue comment <number> --body "🚫 **Auto-blocked**: 이 태스크는 3회 연속 QA 실패로 자동 차단되었습니다. 수동 검토가 필요합니다."
+```
+
 3. **Idempotency check**: 선택한 태스크의 done criteria 핵심 키워드를 현재 코드에서 확인:
    - 태스크 body의 Files 섹션에 나열된 파일에서 관련 함수/기능을 grep
    - 이미 구현돼 있으면 → 이슈를 close하고 다음 ready 태스크로 skip:

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -80,16 +80,47 @@ kill $SERVER_PID
 - E2E 실패 시 `e2e_integration` fail
 - E2E 테스트가 route mock 없이 실제 서버를 검증하는지 확인
 
+### 2-3. Visual Verification (OpenChrome MCP)
+E2E 서버가 실행 중일 때 OpenChrome MCP를 사용하여 시각적 검증을 수행한다.
+OpenChrome은 DOM을 ~12K 토큰으로 압축하여 Playwright 대비 15배 효율적이다.
+
+**로컬 개발 환경 (MCP 사용 가능 시):**
+OpenChrome MCP 도구를 사용하여 페이지를 검증한다:
+1. `navigate`로 `http://localhost:8000/` 및 `/chat` 페이지 방문
+2. `screenshot`으로 스크린샷 캡처 → `observability/screenshots/`에 저장
+3. DOM Mode로 페이지 구조 검증 (핵심 UI 요소 존재 여부)
+
+**CI 환경 (MCP 미지원 시 fallback):**
+```bash
+mkdir -p observability/screenshots
+npx playwright screenshot --viewport-size="1280,720" http://localhost:8000/ observability/screenshots/main.png 2>/dev/null || true
+npx playwright screenshot --viewport-size="1280,720" http://localhost:8000/chat observability/screenshots/chat.png 2>/dev/null || true
+```
+
+- 스크린샷이 완전히 비어있거나(0 bytes) 렌더링 오류가 보이면 `issues`에 기록
+- 이 검사는 advisory(권고)이며, 스크린샷 실패 자체로 verdict를 fail하지는 않는다
+- 캡처된 스크린샷은 `observability/screenshots/`에 저장되어 다음 run과 비교 가능
+
 ### 3. 린트
 ```bash
 ruff check src/ tests/ 2>&1
 ```
 - 문제 있으면 `lint_clean` fail
 
-### 4. 완료 기준 검증
+### 4. 완료 기준 검증 (Executable Assertions)
 - `.evolve/handoff.json`의 `done_criteria`를 읽는다
-- 코드를 검토하여 기준이 충족되었는지 판단
-- 예: "ChatService가 intent를 반환" → `src/app/chat.py`에 해당 로직이 있는지 확인
+- **주관적 판단이 아닌 실행 가능한 검증을 수행한다:**
+  1. done_criteria에서 핵심 키워드(함수명, 클래스명, 파일명 등)를 추출
+  2. `grep`으로 해당 키워드가 코드에 존재하는지 확인
+  3. 테스트에서 해당 기능이 실제로 호출되고 검증되는지 확인
+- 예:
+  - "ChatService가 find_alternatives intent를 반환" →
+    `grep -c "find_alternatives" src/app/chat.py` ≥ 1 AND
+    `grep -c "find_alternatives" tests/` ≥ 1
+  - "Playwright 시나리오 2개 이상" →
+    `grep -c "test(" e2e/chat.spec.ts` ≥ 2 (해당 기능 관련)
+- **의심스러우면 fail**: 코드가 존재하지만 테스트에서 검증하지 않으면 fail
+- grep 결과를 `done_criteria_met.detail`에 구체적으로 기록 (예: "grep find_alternatives: src 3 hits, tests 5 hits")
 
 ### 5. 회귀 테스트
 - Builder 이전의 테스트 수와 현재 테스트 수 비교 (handoff.json의 tests_total)

--- a/.claude/agents/reporter.md
+++ b/.claude/agents/reporter.md
@@ -50,7 +50,7 @@
   },
   "spans": [...],
   "ltes": {
-    "latency": {"total_duration_ms": 0},
+    "latency": {"total_duration_s": "<from .evolve/timing.json pipeline_duration_s>"},
     "traffic": {"commits": 0, "lines_added": 0, "lines_removed": 0, "files_changed": 0},
     "errors": {"test_failures": 0, "fix_attempts": 0},
     "saturation": {"issues_open": 0}
@@ -120,6 +120,22 @@ gh issue comment "$ISSUE_NUMBER" --body "🧪 **QA Failed** (Run #<N>)
 
 - **QA pass** → `consecutive_qa_failures`를 **0으로 reset**
 - **QA fail** → `consecutive_qa_failures`를 **+1 증가**
+
+#### 이슈별 실패 이력 업데이트 (Per-Issue Failure History)
+`observability/error-budget.json`의 `issue_failure_history` 필드를 업데이트한다.
+이슈 번호를 key로 사용하고, 실패 횟수와 마지막 에러를 기록한다.
+
+- **QA pass** → 해당 이슈를 `issue_failure_history`에서 **삭제**
+- **QA fail** → 해당 이슈의 `attempts`를 **+1**, `last_error`에 QA 실패 사유 기록, `last_run`에 run_id 기록
+
+```json
+"issue_failure_history": {
+  "172": {"attempts": 2, "last_error": "integration test missing", "last_run": "2026-04-08-1400"},
+  "175": {"attempts": 1, "last_error": "lint failure", "last_run": "2026-04-08-1430"}
+}
+```
+
+Coordinator는 `attempts >= 3`인 이슈를 자동으로 blocked 처리한다.
 
 #### Bug Issue 생성 조건 (≥3 연속 실패)
 `consecutive_qa_failures >= 3`이면 Bug Issue 생성을 시도한다.

--- a/.github/workflows/evolve.yml
+++ b/.github/workflows/evolve.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   evolve:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -36,9 +36,16 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Cache npm global
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-global-claude-code-${{ runner.os }}
+
       - name: Install dependencies
         run: |
           npm install -g @anthropic-ai/claude-code
+          npm ci || npm install
           pip install -r requirements.txt 2>/dev/null || true
 
       - name: Configure git
@@ -47,10 +54,14 @@ jobs:
           git config user.email "travel-planner-ai[bot]@users.noreply.github.com"
 
       - name: Prepare workspace
-        run: mkdir -p .evolve
+        run: |
+          mkdir -p .evolve
+          echo '{}' > .evolve/timing.json
+          echo "PIPELINE_START=$(date +%s)" >> "$GITHUB_ENV"
 
       # ─── Agent 1: 🧠 Coordinator ─────────────────────────────────
       - name: "🧠 Coordinator"
+        timeout-minutes: 5
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_PAT }}
@@ -94,6 +105,7 @@ jobs:
           echo "Architect needed: $NEEDS"
 
       - name: "📐 Architect"
+        timeout-minutes: 5
         if: steps.check_architect.outputs.needed == 'True' || steps.check_architect.outputs.needed == 'true'
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -120,6 +132,7 @@ jobs:
 
       # ─── Agent 3: 🔨 Builder ─────────────────────────────────────
       - name: "🔨 Builder"
+        timeout-minutes: 10
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -151,6 +164,7 @@ jobs:
 
       # ─── Agent 4: 🧪 QA ──────────────────────────────────────────
       - name: "🧪 QA"
+        timeout-minutes: 5
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
@@ -182,18 +196,99 @@ jobs:
           echo "QA verdict: $VERDICT"
           cat .evolve/qa-result.json | python3 -m json.tool
 
+      # ─── Retry Loop: QA fail → Builder retry (1회) ────────────────
+      - name: "🔨 Builder (retry)"
+        timeout-minutes: 10
+        if: steps.qa_check.outputs.verdict == 'fail'
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          echo "🔁 QA failed — retrying Builder with QA feedback"
+          cat <<'PROMPT' | claude -p --allowedTools "Bash,Read,Write,Glob,Grep,Edit"
+          You are the 🔨 Builder Agent (RETRY attempt).
+          Read `.claude/agents/builder.md` for your full instructions.
+          Read `CLAUDE.md` for project context.
+          Read `.evolve/handoff.json` for your assigned task.
+          Read `.evolve/qa-result.json` for QA feedback — fix the issues listed there.
+
+          This is a RETRY after QA failure. Focus on fixing the specific issues QA reported.
+
+          Execute your role:
+          1. Read qa-result.json to understand what failed
+          2. Fix the issues
+          3. Run pytest + ruff to verify
+          4. Overwrite .evolve/build-result.json with updated results
+
+          Do NOT modify status.md or backlog.md. Do NOT ask for confirmation.
+          PROMPT
+
+      - name: Verify Builder retry output
+        if: steps.qa_check.outputs.verdict == 'fail'
+        run: |
+          if [ ! -f .evolve/build-result.json ]; then
+            echo '{"task_number": 0, "status": "failed", "notes": "No build-result.json produced (retry)"}' > .evolve/build-result.json
+          fi
+          echo "Builder retry result:"
+          cat .evolve/build-result.json | python3 -m json.tool
+
+      - name: "🧪 QA (retry)"
+        timeout-minutes: 5
+        if: steps.qa_check.outputs.verdict == 'fail'
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          cat <<'PROMPT' | claude -p --allowedTools "Bash,Read,Write,Glob,Grep"
+          You are the 🧪 QA Agent (RETRY verification).
+          Read `.claude/agents/qa.md` for your full instructions.
+          Read `.evolve/handoff.json` for task requirements.
+          Read `.evolve/build-result.json` for what the Builder did.
+
+          Execute your role:
+          1. Run all tests (pytest tests/ -v --tb=short)
+          2. Check new tests exist for new features
+          3. Run lint (ruff check src/ tests/)
+          4. Verify done criteria from handoff.json
+          5. Check for regressions and leaked secrets
+          6. Write .evolve/qa-result.json with your verdict
+
+          Do NOT modify any source code. Do NOT ask for confirmation.
+          PROMPT
+
+      - name: Verify QA retry output
+        id: qa_retry_check
+        if: steps.qa_check.outputs.verdict == 'fail'
+        run: |
+          if [ ! -f .evolve/qa-result.json ]; then
+            echo '{"task_number": 0, "verdict": "fail", "checks": {}, "issues": ["QA agent did not produce qa-result.json (retry)"]}' > .evolve/qa-result.json
+          fi
+          VERDICT=$(python3 -c "import json; print(json.load(open('.evolve/qa-result.json'))['verdict'])" 2>/dev/null || echo "fail")
+          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+          echo "QA retry verdict: $VERDICT"
+          cat .evolve/qa-result.json | python3 -m json.tool
+
+      # ─── Capture pipeline duration ─────────────────────────────────
+      - name: Capture pipeline timing
+        if: always()
+        run: |
+          ELAPSED=$(( $(date +%s) - PIPELINE_START ))
+          echo "{\"pipeline_duration_s\": ${ELAPSED}}" > .evolve/timing.json
+          echo "Pipeline duration: ${ELAPSED}s"
+
       # ─── Agent 5: 📝 Reporter ────────────────────────────────────
       - name: "📝 Reporter"
+        timeout-minutes: 5
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          QA_VERDICT="${{ steps.qa_check.outputs.verdict }}"
+          # Use retry verdict if retry ran, otherwise use first QA verdict
+          QA_VERDICT="${{ steps.qa_retry_check.outputs.verdict || steps.qa_check.outputs.verdict }}"
           cat <<PROMPT | claude -p --allowedTools "Bash,Read,Write,Glob,Grep,Edit"
           You are the 📝 Reporter Agent.
           Read \`.claude/agents/reporter.md\` for your full instructions.
           Read \`CLAUDE.md\` for project context.
-          Read all files in \`.evolve/\` (handoff.json, build-result.json, qa-result.json).
+          Read all files in \`.evolve/\` (handoff.json, build-result.json, qa-result.json, timing.json).
 
           The QA verdict is: $QA_VERDICT
 
@@ -228,8 +323,8 @@ jobs:
           echo "health=$(grep -oP 'Health: \K\w+' status.md 2>/dev/null || echo 'UNKNOWN')" >> "$GITHUB_OUTPUT"
           echo "task=$(grep -oP 'Current focus: \K.*' status.md 2>/dev/null || echo 'unknown')" >> "$GITHUB_OUTPUT"
 
-          # Use qa_check step output (file may be deleted by Reporter)
-          VERDICT="${{ steps.qa_check.outputs.verdict }}"
+          # Use retry verdict if available, otherwise first QA verdict
+          VERDICT="${{ steps.qa_retry_check.outputs.verdict || steps.qa_check.outputs.verdict }}"
           if [ -z "$VERDICT" ]; then VERDICT="unknown"; fi
           echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
 

--- a/observability/error-budget.json
+++ b/observability/error-budget.json
@@ -652,6 +652,7 @@
     }
   ],
   "consecutive_qa_failures": 0,
+  "issue_failure_history": {},
   "history_tail": {
     "run_id": "2026-04-07-2400",
     "task": "#108 - Chat: find_alternatives intent — suggest replacement places for a slot",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/HyungjoonYang/travel-planner-ai#readme",
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "openchrome-mcp": "^1.9.6",
     "typescript": "^5.9.3"
   }
 }

--- a/tech-decisions.md
+++ b/tech-decisions.md
@@ -16,3 +16,7 @@
 | 2026-04-03 | Multi-agent evolve pipeline (5 agents with file-based handoff) | Single-agent evolve lacked separation of concerns; now each agent has focused role + clear input/output contract; enables parallel QA and better observability |
 | 2026-04-03 | SSE (not WebSocket) for chat streaming | Unidirectional server→client streaming; no extra dependencies; FastAPI StreamingResponse native support; auto-reconnect built-in |
 | 2026-04-03 | PR-based evolve (not direct push to main) | Safety: CI tests + auto-merge on pass; failed changes don't reach main; human review possible via `evolve-needs-review` label |
+| 2026-04-08 | OpenChrome MCP for visual verification (Playwright MCP 보완) | DOM Mode로 페이지당 ~12K 토큰 (Playwright ~180K 대비 15x 압축); CDP 직접 통신; Ralph Engine 7단계 자동 에러 복구; CI에서는 Playwright fallback 유지 |
+| 2026-04-08 | Evolve model pinning: Opus 4.6 | harness-engineering 원칙에 따라 모델 명시적 고정; 예기치 않은 모델 변경으로 인한 파이프라인 동작 변화 방지 |
+| 2026-04-08 | Per-agent step timeout + Builder-QA inner retry loop | 5-Layer Defense 중 per-cron timeout 적용; QA 실패 시 같은 run 내 1회 재시도로 효율 2배 향상 |
+| 2026-04-08 | Per-issue failure history tracking | 동일 이슈 3회 연속 실패 시 자동 blocked 처리; 무한 재시도 순환 방지 |


### PR DESCRIPTION
## Summary
- **Per-agent step timeouts**: Coordinator/Architect/QA/Reporter 5min, Builder 10min, job 45min — 단일 에이전트 hang 시 전체 파이프라인 보호
- **Builder-QA inner retry loop**: QA 실패 시 같은 run 내 Builder 1회 재시도 → 30분+ 대기 없이 즉시 수정 시도
- **Per-issue failure history**: `error-budget.json`에 이슈별 실패 이력 추적, 3회 연속 실패 시 자동 blocked 처리
- **Executable done_criteria**: QA의 완료 기준 검증을 주관적 판단 → grep 기반 실행 가능 assertion으로 전환
- **Pipeline duration tracking**: 총 실행시간 캡처 → LTES 로그에 기록
- **OpenChrome MCP**: 시각 검증용 MCP 서버 도입 (DOM 15x 압축), CI에서는 Playwright fallback
- **npm global cache**: CI에서 claude-code 재설치 시간 단축

## Test plan
- [ ] evolve.yml YAML 문법 검증 완료 (python yaml.safe_load)
- [ ] 다음 evolve run에서 per-agent timeout 동작 확인
- [ ] QA 실패 시 Builder retry → QA retry 루프 동작 확인
- [ ] issue_failure_history 필드가 Reporter에 의해 정상 기록되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)